### PR TITLE
revert pickAll

### DIFF
--- a/Query.cls
+++ b/Query.cls
@@ -695,10 +695,6 @@ public class Query {
     Map<String, Schema.SObjectField> fieldMap = this.sObjectType.getDescribe().fields.getMap();
     if (this.isSelectAll) {
       for (String fieldName : fieldMap.keyset()) {
-        if (this.sObjectType == Opportunity.SObjectType && fieldName == 'iqscore') {
-          // 商談でエラーになる標準項目なのでスキップ
-          continue;
-        }
         if (selectFieldsString == null || selectFieldsString == '') {
           selectFieldsString = fieldName;
         } else {

--- a/Query.cls
+++ b/Query.cls
@@ -694,7 +694,17 @@ public class Query {
     String selectFieldsString = '';
     Map<String, Schema.SObjectField> fieldMap = this.sObjectType.getDescribe().fields.getMap();
     if (this.isSelectAll) {
-      selectFieldsString = 'FIELDS(ALL)';
+      for (String fieldName : fieldMap.keyset()) {
+        if (this.sObjectType == Opportunity.SObjectType && fieldName == 'iqscore') {
+          // 商談でエラーになる標準項目なのでスキップ
+          continue;
+        }
+        if (selectFieldsString == null || selectFieldsString == '') {
+          selectFieldsString = fieldName;
+        } else {
+          selectFieldsString = selectFieldsString + ', ' + fieldName;
+        }
+      }
     } else {
       selectFieldsString = String.join(this.selectFields, ', ');
     }

--- a/tests/Query_T.cls
+++ b/tests/Query_T.cls
@@ -22,8 +22,15 @@ public with sharing class Query_T {
 
     testTitle = '正常系: 全フィールド取得を指定してレコードを取得するクエリを作成できる';
     query = (new Query()).source(oppSource).pickAll().condition('Id', '=', '006000000000000');
-    queryString = 'SELECT FIELDS(ALL) FROM Opportunity WHERE (Id = \'006000000000000\')'; 
-    Assert.areEqual(queryString, query.toSoql(), testTitle);
+    queryString = query.toSoql();
+    Assert.isTrue(queryString.startsWith('SELECT '), testTitle);
+    Assert.isTrue(queryString.contains(' FROM Opportunity '), testTitle);
+    Assert.isTrue(queryString.endsWith(' WHERE (Id = \'006000000000000\')'), testTitle);
+    // pickAllした時、フィールド名は小文字になる
+    Assert.isTrue(queryString.contains('id'), testTitle);
+    Assert.isTrue(queryString.contains('name'), testTitle);
+    Assert.isTrue(queryString.contains('closedate'), testTitle);
+    Assert.isTrue(queryString.contains('stagename'), testTitle);
 
     testTitle = '正常系: AND条件によるクエリを作成できる';
     System.debug(testTitle);


### PR DESCRIPTION
FIELD(ALL) occur an error `The SOQL FIELDS function is not supported with an unbounded set of fields in this API.`.
This error coused by using `FIELD(ALL)` clause in Apex or Bulk Api.