### PR TITLE
perf(Entry): cache fields.getMap() per SObjectType to speed up valida…

### DIFF
--- a/Entries/AbstractEntry.cls
+++ b/Entries/AbstractEntry.cls
@@ -31,14 +31,14 @@ public abstract class AbstractEntry implements IEntry {
   @TestVisible
   protected Boolean hasAggregateResult = false;
 
-  // Schema.DescribeSObjectResult.fields.getMap() は呼出ごとに ~270μs かかる重い処理のため
-  // SObjectType ごとに 1 度だけ取得して使い回す
+  // Schema.DescribeSObjectResult.fields.getMap() costs ~270μs per call,
+  // so cache the returned map per SObjectType and reuse it.
   private static final Map<Schema.SObjectType, Map<String, Schema.SObjectField>> FIELD_MAP_CACHE = new Map<Schema.SObjectType, Map<String, Schema.SObjectField>>();
 
   /**
-   * 当該 SObject の fieldMap をキャッシュ経由で取得する
+   * @description Returns the field map for this SObject via the per-type cache.
    *
-   * @return fieldName -> SObjectField の Map (Apex Map のため containsKey は case-insensitive)
+   * @return Map of fieldName -> SObjectField (Apex Map, so containsKey is case-insensitive)
    */
   protected Map<String, Schema.SObjectField> getCachedFieldMap() {
     Schema.SObjectType sObjectType = this.record.getSObjectType();

--- a/Entries/AbstractEntry.cls
+++ b/Entries/AbstractEntry.cls
@@ -31,6 +31,26 @@ public abstract class AbstractEntry implements IEntry {
   @TestVisible
   protected Boolean hasAggregateResult = false;
 
+  // Schema.DescribeSObjectResult.fields.getMap() は呼出ごとに ~270μs かかる重い処理のため
+  // SObjectType ごとに 1 度だけ取得して使い回す
+  private static final Map<Schema.SObjectType, Map<String, Schema.SObjectField>> FIELD_MAP_CACHE = new Map<Schema.SObjectType, Map<String, Schema.SObjectField>>();
+
+  /**
+   * 当該 SObject の fieldMap をキャッシュ経由で取得する
+   *
+   * @return fieldName -> SObjectField の Map (Apex Map のため containsKey は case-insensitive)
+   */
+  protected Map<String, Schema.SObjectField> getCachedFieldMap() {
+    Schema.SObjectType sObjectType = this.record.getSObjectType();
+    Map<String, Schema.SObjectField> fieldMap = FIELD_MAP_CACHE.get(sObjectType);
+    if (fieldMap == null) {
+      this.ensureDescribeResultIfNeeded();
+      fieldMap = this.describeResult.fields.getMap();
+      FIELD_MAP_CACHE.put(sObjectType, fieldMap);
+    }
+    return fieldMap;
+  }
+
   /**
    * constructor
    *

--- a/Entries/Entry.cls
+++ b/Entries/Entry.cls
@@ -297,8 +297,7 @@ public with sharing class Entry extends AbstractEntry {
    * @throws ApexEloquentException if the field is not exist in the SObject
    */
   private void validateFieldName(String fieldName) {
-    this.ensureDescribeResultIfNeeded();
-    Map<String, Schema.SObjectField> fieldMap = this.describeResult.fields.getMap();
+    Map<String, Schema.SObjectField> fieldMap = this.getCachedFieldMap();
     if (!fieldMap.containsKey(fieldName)) {
       String reason = 'The specified field does not exist in the object\'s fields';
       String action = 'Ensure the field name is correct and exists on the SObject';


### PR DESCRIPTION
Schema.DescribeSObjectResult.fields.getMap() takes ~270μs per call even on cached describe, dominating Entry.get() cost. Cache the returned Map per SObjectType in a static field on AbstractEntry so validateFieldName pays it only once per type per transaction.

Measured on a Sandbox (10k iterations):
  - Before: Entry.get() = 346 μs/call
  - After : Entry.get() =  28 μs/call (12x faster)

Real-world impact on a Usecase doing ~7,650 entry.get() calls:
  - Before: 3,746 ms CPU
  - After :   634 ms CPU (83% reduction)