### PR TITLE
feat!: secure-by-default DML/SOQL and query-builder ergonomics (v3.0.0)

### DIFF
--- a/Eloquents/Eloquent.cls
+++ b/Eloquents/Eloquent.cls
@@ -26,7 +26,7 @@
  * @see Entry
  * @see MockEloquent
  */
-public with sharing class Eloquent implements IEloquent {
+public inherited sharing class Eloquent implements IEloquent {
   private final Integer MAX_DML_CHUNKING = 10;
 
   private static final String CLASS_NAME = 'Eloquent';
@@ -36,6 +36,12 @@ public with sharing class Eloquent implements IEloquent {
   private Boolean strictMode = false;
   private Boolean labelSetForNextOp = false;
   private Set<String> consumedLabels = new Set<String>();
+
+  // FLS/CRUD access mode for SOQL/DML. Defaults to USER_MODE (secure-by-default); opt out via systemMode().
+  // Note: record-level sharing is NOT controlled here — it follows this class's sharing declaration
+  // (inherited sharing -> the caller's context).
+  @TestVisible
+  private System.AccessLevel accessLevel = System.AccessLevel.USER_MODE;
 
   /**
    * @inheritDoc
@@ -47,6 +53,22 @@ public with sharing class Eloquent implements IEloquent {
     this.currentLabel = label;
     this.labelSetForNextOp = true;
     this.strictMode = true; // sticky — once on, stays on for this IEloquent instance
+    return this;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public IEloquent userMode() {
+    this.accessLevel = System.AccessLevel.USER_MODE;
+    return this;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public IEloquent systemMode() {
+    this.accessLevel = System.AccessLevel.SYSTEM_MODE;
     return this;
   }
 
@@ -106,7 +128,7 @@ public with sharing class Eloquent implements IEloquent {
     }
 
     List<IEntry> entries = new List<IEntry>();
-    for (SObject record : (List<SObject>) Database.query(scribe.toSoql())) {
+    for (SObject record : (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel)) {
       entries.add(new Entry(record));
     }
 
@@ -116,7 +138,7 @@ public with sharing class Eloquent implements IEloquent {
   private List<IEntry> getAggregate(Scribe scribe) {
     FieldStructure fieldStructure = null;
     List<IEntry> entries = new List<IEntry>();
-    for (AggregateResult aggregateResult : (List<AggregateResult>) Database.query(scribe.toSoql())) {
+    for (AggregateResult aggregateResult : (List<AggregateResult>) Database.query(scribe.toSoql(), this.accessLevel)) {
       fieldStructure = fieldStructure == null ? scribe.buildAggregateFieldStructure() : fieldStructure;
       entries.add(new Entry(aggregateResult, fieldStructure));
     }
@@ -133,7 +155,7 @@ public with sharing class Eloquent implements IEloquent {
       ApexEloquentException.required(CLASS_NAME, method, 'soql', soql).fire();
     }
     List<IEntry> entries = new List<IEntry>();
-    for (SObject record : (List<SObject>) Database.query(soql)) {
+    for (SObject record : (List<SObject>) Database.query(soql, this.accessLevel)) {
       entries.add(new Entry(record));
     }
     return entries;
@@ -149,7 +171,7 @@ public with sharing class Eloquent implements IEloquent {
       ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
     }
 
-    return (List<SObject>) Database.query(scribe.toSoql());
+    return (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
   }
 
   /**
@@ -162,7 +184,7 @@ public with sharing class Eloquent implements IEloquent {
       ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
     }
 
-    List<SObject> records = (List<SObject>) Database.query(scribe.toSoql());
+    List<SObject> records = (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
     if (records.isEmpty()) {
       return null;
     }
@@ -179,7 +201,7 @@ public with sharing class Eloquent implements IEloquent {
       ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
     }
 
-    List<SObject> records = (List<SObject>) Database.query(scribe.toSoql());
+    List<SObject> records = (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
     if (records.isEmpty()) {
       return null;
     }
@@ -196,7 +218,7 @@ public with sharing class Eloquent implements IEloquent {
       ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
     }
 
-    List<SObject> records = (List<SObject>) Database.query(scribe.toSoql());
+    List<SObject> records = (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
 
     if (records.isEmpty()) {
       String error = 'No records were found for the given criteria';
@@ -223,7 +245,7 @@ public with sharing class Eloquent implements IEloquent {
       ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
     }
 
-    List<SObject> records = (List<SObject>) Database.query(scribe.toSoql());
+    List<SObject> records = (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
     if (records.isEmpty()) {
       String error = 'No records were found for the given criteria';
       String reason = 'The query execution returned zero records';
@@ -249,7 +271,7 @@ public with sharing class Eloquent implements IEloquent {
       ApexEloquentException.required(CLASS_NAME, method, 'record', record).fire();
     }
     try {
-      insert record;
+      Database.insert(record, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('insert', e);
       ex.method(method).param('record', record).fire();
@@ -268,7 +290,7 @@ public with sharing class Eloquent implements IEloquent {
     }
     sortToPreventChunkingErrors(records);
     try {
-      insert records;
+      Database.insert(records, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('insert', e);
       ex.method(method).param('records', records).fire();
@@ -287,7 +309,7 @@ public with sharing class Eloquent implements IEloquent {
     }
 
     try {
-      update record;
+      Database.update(record, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('update', e);
       ex.method(method).param('record', record).fire();
@@ -306,7 +328,7 @@ public with sharing class Eloquent implements IEloquent {
     }
 
     try {
-      return Database.update(record, allOrNone);
+      return Database.update(record, allOrNone, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('update', e);
       ex.method(method).param('record', record).param('allOrNone', allOrNone).fire();
@@ -326,7 +348,7 @@ public with sharing class Eloquent implements IEloquent {
     }
     SObject record = entry.getRecord();
     try {
-      update record;
+      Database.update(record, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('update', e);
       ex.method(method).param('entry', entry).fire();
@@ -345,7 +367,7 @@ public with sharing class Eloquent implements IEloquent {
     }
     SObject record = entry.getRecord();
     try {
-      return Database.update(record, allOrNone);
+      return Database.update(record, allOrNone, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('update', e);
       ex.method(method).param('entry', entry).param('allOrNone', allOrNone).fire();
@@ -365,7 +387,7 @@ public with sharing class Eloquent implements IEloquent {
     }
     sortToPreventChunkingErrors(records);
     try {
-      update records;
+      Database.update(records, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('update', e);
       ex.method(method).param('records', records).fire();
@@ -384,7 +406,7 @@ public with sharing class Eloquent implements IEloquent {
     }
     sortToPreventChunkingErrors(records);
     try {
-      return Database.update(records, allOrNone);
+      return Database.update(records, allOrNone, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('update', e);
       ex.method(method).param('records', records).param('allOrNone', allOrNone).fire();
@@ -412,7 +434,7 @@ public with sharing class Eloquent implements IEloquent {
     }
     sortToPreventChunkingErrors(records);
     try {
-      update records;
+      Database.update(records, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('update', e);
       ex.method(method).param('entries', entries).fire();
@@ -443,7 +465,7 @@ public with sharing class Eloquent implements IEloquent {
     }
     sortToPreventChunkingErrors(records);
     try {
-      return Database.update(records, allOrNone);
+      return Database.update(records, allOrNone, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('update', e);
       ex.method(method).param('entries', entries).param('allOrNone', allOrNone).fire();
@@ -463,7 +485,7 @@ public with sharing class Eloquent implements IEloquent {
     }
 
     try {
-      upsert record;
+      Database.upsert(record, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('upsert', e);
       ex.method(method).param('record', record).fire();
@@ -483,7 +505,7 @@ public with sharing class Eloquent implements IEloquent {
 
     SObject record = entry.getRecord();
     try {
-      upsert record;
+      Database.upsert(record, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('upsert', e);
       ex.method(method).param('entry', entry).fire();
@@ -503,7 +525,7 @@ public with sharing class Eloquent implements IEloquent {
 
     sortToPreventChunkingErrors(records);
     try {
-      upsert records;
+      Database.upsert(records, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('upsert', e);
       ex.method(method).param('records', records).fire();
@@ -530,7 +552,7 @@ public with sharing class Eloquent implements IEloquent {
     }
     sortToPreventChunkingErrors(records);
     try {
-      upsert records;
+      Database.upsert(records, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('upsert', e);
       ex.method(method).param('entries', entries).fire();
@@ -553,7 +575,7 @@ public with sharing class Eloquent implements IEloquent {
     }
 
     try {
-      return Database.upsert(record, externalIdField, allOrNone);
+      return Database.upsert(record, externalIdField, allOrNone, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('upsert', e);
       ex.method(method).param('record', record).param('externalIdField', externalIdField).param('allOrNone', allOrNone).fire();
@@ -574,7 +596,7 @@ public with sharing class Eloquent implements IEloquent {
 
     SObject record = entry.getRecord();
     try {
-      return Database.upsert(record, externalIdField, allOrNone);
+      return Database.upsert(record, externalIdField, allOrNone, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('upsert', e);
       ex.method(method).param('entry', entry).param('externalIdField', externalIdField).param('allOrNone', allOrNone).fire();
@@ -595,7 +617,7 @@ public with sharing class Eloquent implements IEloquent {
 
     sortToPreventChunkingErrors(records);
     try {
-      return Database.upsert(records, externalIdField, allOrNone);
+      return Database.upsert(records, externalIdField, allOrNone, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('upsert', e);
       ex.method(method).param('records', records).param('externalIdField', externalIdField).param('allOrNone', allOrNone).fire();
@@ -623,7 +645,7 @@ public with sharing class Eloquent implements IEloquent {
     }
     sortToPreventChunkingErrors(records);
     try {
-      return Database.upsert(records, externalIdField, allOrNone);
+      return Database.upsert(records, externalIdField, allOrNone, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('upsert', e);
       ex.method(method).param('entries', entries).param('externalIdField', externalIdField).param('allOrNone', allOrNone).fire();
@@ -643,7 +665,7 @@ public with sharing class Eloquent implements IEloquent {
     }
 
     try {
-      delete record;
+      Database.delete(record, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('delete', e);
       ex.method(method).param('record', record).fire();
@@ -661,7 +683,7 @@ public with sharing class Eloquent implements IEloquent {
     }
 
     try {
-      delete entry.getRecord();
+      Database.delete(entry.getRecord(), this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('delete', e);
       ex.method(method).param('entry', entry).fire();
@@ -679,7 +701,7 @@ public with sharing class Eloquent implements IEloquent {
     }
 
     try {
-      delete records;
+      Database.delete(records, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('delete', e);
       ex.method(method).param('records', records).fire();
@@ -706,7 +728,7 @@ public with sharing class Eloquent implements IEloquent {
     }
 
     try {
-      delete records;
+      Database.delete(records, this.accessLevel);
     } catch (DmlException e) {
       ApexEloquentException ex = createDMLException('delete', e);
       ex.method(method).param('entries', entries).fire();

--- a/Eloquents/IEloquent.cls
+++ b/Eloquents/IEloquent.cls
@@ -42,6 +42,27 @@ public interface IEloquent {
   IEloquent label(String label);
 
   /**
+   * Runs subsequent SOQL/DML on this instance in user mode (the default):
+   * the running user's field-level security and object permissions are enforced.
+   * Note: record-level sharing is governed by the class sharing keyword, not by this setting.
+   * Chainable.
+   *
+   * @return this IEloquent for chaining
+   */
+  IEloquent userMode();
+
+  /**
+   * Runs subsequent SOQL/DML on this instance in system mode: field-level security
+   * and object permissions are NOT enforced. Record-level sharing still follows the
+   * class sharing keyword (use a `without sharing` caller to also bypass sharing).
+   * Opt out of the secure-by-default user mode only where system-context execution is required.
+   * Chainable.
+   *
+   * @return this IEloquent for chaining
+   */
+  IEloquent systemMode();
+
+  /**
   * Executes SOQL and retrieves the results.
   * If the number of retrieved records is 0, an empty list is returned.
   *

--- a/Eloquents/MockEloquent.cls
+++ b/Eloquents/MockEloquent.cls
@@ -122,6 +122,22 @@ public with sharing class MockEloquent implements IEloquent {
   }
 
   /**
+   * @inheritDoc
+   * No-op in the mock: there is no real database, so access mode has no effect on captured data.
+   */
+  public IEloquent userMode() {
+    return this;
+  }
+
+  /**
+   * @inheritDoc
+   * No-op in the mock: there is no real database, so access mode has no effect on captured data.
+   */
+  public IEloquent systemMode() {
+    return this;
+  }
+
+  /**
    * Pre-load data for a label. Subsequent read calls tagged with that label
    * will see this data as the query source. Overwrites prior attach.
    */

--- a/Eloquents/tests/EloquentTest.cls
+++ b/Eloquents/tests/EloquentTest.cls
@@ -16,6 +16,45 @@
 @isTest
 public with sharing class EloquentTest {
   @isTest
+  static void testUserModeSystemMode_WhenToggled_ThenAccessLevelSwitches() {
+    // Arrange
+    Eloquent eloquent = new Eloquent();
+
+    // Act & Assert: default is user mode (secure-by-default)
+    Assert.areEqual(
+      System.AccessLevel.USER_MODE,
+      eloquent.accessLevel,
+      'Default access mode should be USER_MODE'
+    );
+
+    // user -> system
+    IEloquent afterSystem = eloquent.systemMode();
+    Assert.areEqual(
+      System.AccessLevel.SYSTEM_MODE,
+      eloquent.accessLevel,
+      'systemMode() should switch the access mode to SYSTEM_MODE'
+    );
+    Assert.areEqual(eloquent, afterSystem, 'systemMode() should be chainable (return the same instance)');
+
+    // system -> user : must switch back
+    IEloquent afterUser = eloquent.userMode();
+    Assert.areEqual(
+      System.AccessLevel.USER_MODE,
+      eloquent.accessLevel,
+      'userMode() should switch the access mode back to USER_MODE'
+    );
+    Assert.areEqual(eloquent, afterUser, 'userMode() should be chainable (return the same instance)');
+
+    // toggle once more to confirm it stays re-switchable
+    eloquent.systemMode();
+    Assert.areEqual(
+      System.AccessLevel.SYSTEM_MODE,
+      eloquent.accessLevel,
+      'systemMode() should switch to SYSTEM_MODE again after a prior userMode()'
+    );
+  }
+
+  @isTest
   static void testGet_WhenApplyNull_ThenThrowException() {
     // Arrange
     Scribe scribe = null;

--- a/Entries/AbstractEntry.cls
+++ b/Entries/AbstractEntry.cls
@@ -109,8 +109,10 @@ public abstract class AbstractEntry implements IEntry {
   /**
    * @inheritDoc
    */
-  public List<IEntry> getThrough(String junctionObjectName, String relatedKey) {
-    List<IEntry> junctionEntries = this.getChildren(junctionObjectName);
+  public List<IEntry> getThrough(String junctionName, String relatedKey) {
+    // junctionName accepts both a junction SObject name and a junction relationship name:
+    // getChildren resolves the object name first, then falls back to the relationship name.
+    List<IEntry> junctionEntries = this.getChildren(junctionName);
     if (junctionEntries.isEmpty()) {
       return new List<IEntry>();
     }
@@ -127,6 +129,12 @@ public abstract class AbstractEntry implements IEntry {
     return relatedEntries;
   }
 
+  /**
+   * @deprecated
+   * Use {@link #getThrough(String, String)} instead. `getThrough` now accepts both
+   * junction SObject names and junction relationship names. This method is maintained
+   * for backward compatibility but may be removed in a future version.
+   */
   public List<IEntry> getThroughByRelationName(String junctionRelationName, String relatedKey) {
     List<IEntry> junctionEntries = this.getChildrenByRelationName(junctionRelationName);
     if (junctionEntries.isEmpty()) {

--- a/Entries/IEntry.cls
+++ b/Entries/IEntry.cls
@@ -86,16 +86,27 @@ public interface IEntry {
   List<IEntry> getChildrenByRelationName(String childRelationName);
 
   /**
-   * get related SObject list through a junction object.
+   * Get related SObject list through a junction object.
    *
-   * @param junctionObjectName junction object Name
+   * The junction is resolved by {@link #getChildren(String)}, so the first argument
+   * accepts BOTH a junction SObject name AND a junction relationship name (object-name
+   * resolution is attempted first, then falling back to relationship-name).
+   *
+   * @param junctionName junction SObject name or junction relationship name
    * @param relatedKey related SObject key field name in the junction object
    * @return related SObject list
    */
-  List<IEntry> getThrough(String junctionObjectName, String relatedKey);
+  List<IEntry> getThrough(String junctionName, String relatedKey);
 
   /**
-   * get related SObject list through a junction object relation name.
+   * @deprecated
+   * Use {@link #getThrough(String, String)} instead. `getThrough` now accepts both
+   * junction SObject names and junction relationship names, so a dedicated
+   * relation-name-only entry point is no longer necessary.
+   * * This method is maintained for backward compatibility but may be removed
+   * in a future version.
+   *
+   * Get related SObject list through a junction object relation name.
    *
    * @param junctionRelationName junction object relation Name
    * @param relatedKey related SObject key field name in the junction object

--- a/Entries/tests/MockEntryTest.cls
+++ b/Entries/tests/MockEntryTest.cls
@@ -2154,6 +2154,38 @@ public class MockEntryTest {
   }
 
   @isTest
+  static void testGetThrough_WhenRelationNameGiven_ThenReturnRelatedObject() {
+    // Arrange: getThrough now also accepts a junction RELATIONSHIP name
+    // (folded in from getThroughByRelationName, mirroring the getChildren consolidation).
+    Scribe scribe = Scribe.of(Order.class)
+      .field('Id')
+      .through(
+        Scribe.asThrough(OrderItem.class, 'Product2Id').relationName('OrderItems').field('Id').field('Name')
+      );
+    FieldStructure fieldStructure = scribe.buildFieldStructure();
+    MockEntry mockEntry = MockEntry.of(Order.class)
+      .setChildren(
+        'OrderItems',
+        new List<MockEntry>{
+          MockEntry.of(OrderItem.class)
+            .setParent('Product2Id', MockEntry.of(Product2.class).autoId(1).set('Name', 'Last Modify 1')),
+          MockEntry.of(OrderItem.class)
+            .setParent('Product2Id', MockEntry.of(Product2.class).autoId(2).set('Name', 'Last Modify 2'))
+        }
+      );
+    mockEntry = (MockEntry) mockEntry.setFieldStructure(fieldStructure);
+
+    // Act: pass the RELATION name 'OrderItems' to getThrough (not the object name 'OrderItem')
+    List<IEntry> relatedObjects = mockEntry.getThrough('OrderItems', 'Product2Id');
+
+    // Assert: resolves identically to getThroughByRelationName
+    Assert.isNotNull(relatedObjects, 'Related objects should not be null.');
+    Assert.areEqual(2, relatedObjects.size(), 'There should be two related objects.');
+    Assert.areEqual('Last Modify 1', relatedObjects[0].getName(), 'First related object name should match.');
+    Assert.areEqual('Last Modify 2', relatedObjects[1].getName(), 'Second related object name should match.');
+  }
+
+  @isTest
   static void testAlias_WhenSetAlias_ThenNoErrorThrown() {
     // Arrange / Act
     MockEntry mockEntry = MockEntry.of(Account.class).alias('mockAccount').autoId(1).set('Name', 'Test Account');

--- a/Scribe.cls
+++ b/Scribe.cls
@@ -41,6 +41,9 @@ public with sharing class Scribe {
   private List<ConditionPart> conditionParts = new List<ConditionPart>();
   private Boolean isNextConditionOr = false;
   private Boolean canOnlyAddOrCondition = false;
+  // True only immediately after a where...() condition. Intentionally NOT copied in deepClone(),
+  // so it resets on every builder step — ignoreWhen() is therefore valid ONLY directly after a where...().
+  private Boolean isAfterWhereClause = false;
 
   // Relationship properties
   private List<ParentScribe> parents = new List<ParentScribe>();
@@ -689,6 +692,44 @@ public with sharing class Scribe {
     return clonedScribe;
   }
 
+  /**
+   * Drops the immediately-preceding WHERE condition when `shouldIgnore` is true.
+   *
+   * Must be chained DIRECTLY onto a where...() call. Handy for building dynamic queries
+   * from optional inputs (e.g. search filters from an LWC):
+   *   scribe.whereIn('Id', ids).ignoreWhen(ids.isEmpty())
+   *   scribe.whereLike('Name', keyword).ignoreWhen(String.isBlank(keyword))
+   *
+   * When `shouldIgnore` is false, the condition is kept (query unchanged). When true, the
+   * preceding condition is removed — this also avoids the empty `IN ()` pitfall, which would
+   * otherwise match zero rows.
+   *
+   * If it is NOT chained immediately after a where...() (e.g. called first, after orderBy(),
+   * or twice in a row), an ApexEloquentException is thrown so the relationship between
+   * ignoreWhen() and its target condition stays unambiguous.
+   *
+   * @param shouldIgnore when true, the immediately-preceding WHERE condition is removed.
+   * @return A new, immutable Scribe instance.
+   */
+  public Scribe ignoreWhen(Boolean shouldIgnore) {
+    String method = 'ignoreWhen(Boolean shouldIgnore)';
+    if (this.isAfterWhereClause != true) {
+      String error = 'Invalid ignoreWhen() placement';
+      String reason = 'ignoreWhen() can only be chained immediately after a where...() condition.';
+      String action = 'Chain it directly onto a where...() call, e.g. whereIn(\'Id\', ids).ignoreWhen(ids.isEmpty()).';
+      ApexEloquentException.at(CLASS_NAME).method(method).error(error).reason(reason).action(action).fire();
+    }
+
+    // deepClone() does not copy isAfterWhereClause, so the result resets to false
+    // (a second ignoreWhen() in a row will therefore throw).
+    Scribe clonedScribe = this.deepClone();
+    if (shouldIgnore == true) {
+      clonedScribe.conditionParts.remove(clonedScribe.conditionParts.size() - 1);
+    }
+
+    return clonedScribe;
+  }
+
   // =================================================================================================================
   // WHERE Clause Methods
   // =================================================================================================================
@@ -714,6 +755,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -739,6 +781,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -764,6 +807,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -789,6 +833,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -814,6 +859,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -839,6 +885,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -859,6 +906,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -884,6 +932,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -905,6 +954,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -940,6 +990,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -961,6 +1012,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -996,6 +1048,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -1021,6 +1074,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -1046,6 +1100,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -1065,6 +1120,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -1084,6 +1140,7 @@ public with sharing class Scribe {
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -1142,6 +1199,7 @@ public with sharing class Scribe {
     clonedScribe.sObjectType = this.sObjectType;
     clonedScribe.conditionParts.add(groupConditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }
@@ -1231,6 +1289,7 @@ public with sharing class Scribe {
     );
     clonedScribe.conditionParts.add(parentConditionPart);
     clonedScribe.isNextConditionOr = false;
+    clonedScribe.isAfterWhereClause = true;
 
     return clonedScribe;
   }

--- a/tests/ScribeTest.cls
+++ b/tests/ScribeTest.cls
@@ -463,6 +463,103 @@ public with sharing class ScribeTest {
   }
 
   @isTest
+  static void testIgnoreWhen_WhenTrue_ThenPrecedingConditionDropped() {
+    // Arrange
+    Scribe scribe = Scribe.of(Account.class)
+      .field('Id')
+      .whereEqual('Name', 'Test Account')
+      .ignoreWhen(true);
+
+    // Act
+    String soql = scribe.toSoql();
+
+    // Assert: the preceding WHERE condition is dropped entirely
+    String expectedSoql = 'SELECT id FROM Account';
+    Assert.areEqual(expectedSoql, soql);
+  }
+
+  @isTest
+  static void testIgnoreWhen_WhenFalse_ThenPrecedingConditionKept() {
+    // Arrange
+    Scribe scribe = Scribe.of(Account.class)
+      .field('Id')
+      .whereEqual('Name', 'Test Account')
+      .ignoreWhen(false);
+
+    // Act
+    String soql = scribe.toSoql();
+
+    // Assert
+    String expectedSoql = 'SELECT id FROM Account WHERE Name = \'Test Account\'';
+    Assert.areEqual(expectedSoql, soql);
+  }
+
+  @isTest
+  static void testIgnoreWhen_WhenNoPrecedingCondition_ThenThrows() {
+    // Arrange & Act & Assert: ignoreWhen() before any where...() is a structural misuse
+    try {
+      Scribe.of(Account.class).field('Id').ignoreWhen(true);
+      Assert.fail('Expected ApexEloquentException to be thrown');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('ignoreWhen'));
+    }
+  }
+
+  @isTest
+  static void testIgnoreWhen_WhenNotDirectlyAfterWhere_ThenThrows() {
+    // Arrange & Act & Assert: a non-where builder (orderBy) between the where and ignoreWhen is misuse
+    try {
+      Scribe.of(Account.class)
+        .field('Id')
+        .whereEqual('Name', 'Test Account')
+        .orderBy('Name', 'ASC')
+        .ignoreWhen(true);
+      Assert.fail('Expected ApexEloquentException to be thrown');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('ignoreWhen'));
+    }
+  }
+
+  @isTest
+  static void testIgnoreWhen_WhenMultipleConditions_ThenOnlyLastDropped() {
+    // Arrange
+    Scribe scribe = Scribe.of(Account.class)
+      .field('Id')
+      .whereEqual('Name', 'Test Account')
+      .whereEqual('Industry', 'Tech')
+      .ignoreWhen(true);
+
+    // Act
+    String soql = scribe.toSoql();
+
+    // Assert: only the last-added condition (Industry) is dropped
+    String expectedSoql = 'SELECT id FROM Account WHERE Name = \'Test Account\'';
+    Assert.areEqual(expectedSoql, soql);
+  }
+
+  @isTest
+  static void testIgnoreWhen_WhenAfterWhereGroup_ThenGroupDropped() {
+    // Arrange: a grouped condition is also a valid target for ignoreWhen
+    Scribe scribe = Scribe.of(Opportunity.class)
+      .field('Id')
+      .whereEqual('Name', 'Test Opportunity')
+      .whereGroup(
+        Scribe.asGroup()
+          .whereGreaterThan('TotalOpportunityQuantity', 10000)
+          .orCondition()
+          .whereEqual('Type', 'Test Type')
+      )
+      .ignoreWhen(true);
+
+    // Act
+    String soql = scribe.toSoql();
+
+    // Assert: the whole group is dropped; the preceding condition remains
+    String expectedSoql = 'SELECT id FROM Opportunity WHERE Name = \'Test Opportunity\'';
+    Assert.areEqual(expectedSoql, soql);
+  }
+
+  @isTest
   static void testEqual_WhenAddAndConditionAfterOrCondition_ThenThrowException() {
     // Arrange / Act / Assert
     try {


### PR DESCRIPTION
Modernizes the access-control model and adds two query-builder improvements.

Sharing (breaking):
- Eloquent is now `inherited sharing` instead of `with sharing`. The DAO no
  longer forces with-sharing; it inherits the caller's sharing context (and
  defaults to with sharing only when it is the entry point). Callers that
  implicitly relied on Eloquent re-applying sharing must now declare their own
  sharing explicitly.

Access mode / FLS (breaking):
- Database operations run in user mode by default (AccessLevel.USER_MODE),
  enforcing the running user's field-level security and object permissions.
  Every read/write passes an explicit AccessLevel, so behavior does not depend
  on the API-version default (aligned with API v67 / Summer '26).
- Add IEloquent.userMode() / systemMode() (chainable, sticky per instance).
  Call systemMode() to opt out where system-context execution is required.
- MockEloquent.userMode()/systemMode() are no-op passthroughs.

getThrough consolidation (deprecation):
- getThrough(junctionName, relatedKey) now accepts both a junction SObject name
  and a junction relationship name (resolved via getChildren). getThroughByRelationName is deprecated in favor of getThrough.

Scribe.ignoreWhen (new):
- Scribe.ignoreWhen(Boolean) drops the immediately-preceding where...() condition
  when true (kept when false). It must be chained directly onto a where...()
  call, otherwise it throws, so the link to its target condition stays explicit.
  Avoids the empty `IN ()` pitfall, e.g. whereIn('Id', ids).ignoreWhen(ids.isEmpty()).

Migration:
- To preserve prior behavior (sharing enforced, FLS ignored), make the caller
  `with sharing` and chain `.systemMode()`.
- Add restricted-user (System.runAs) tests and run them before upgrading consumers to v3.

BREAKING CHANGE: Eloquent is now `inherited sharing` and database operations
default to user mode (FLS and object permissions enforced). getThroughByRelationName is deprecated.