### PR TITLE
Fix MockEntry.getParent NPE when parent is staged as null

### DIFF
--- a/Entries/MockEntry.cls
+++ b/Entries/MockEntry.cls
@@ -858,6 +858,13 @@ public with sharing class MockEntry extends AbstractEntry {
 
     if (this.fieldToValue.containsKey(parentIdFieldName)) {
       IEntry resultEntry = (IEntry) this.fieldToValue.get(parentIdFieldName);
+      // A parent explicitly staged as null (setParent(field, null)) means "the parent
+      // record does not exist". Return null to match Entry.getParent(), which returns
+      // null in the same case — without this guard, the production-side null branch
+      // cannot be verified in unit tests.
+      if (resultEntry == null) {
+        return null;
+      }
       if (this.skipFieldValidation && resultEntry instanceof MockEntry) {
         resultEntry = ((MockEntry) resultEntry).withoutFieldValidation();
       }

--- a/Entries/tests/MockEntryTest.cls
+++ b/Entries/tests/MockEntryTest.cls
@@ -308,6 +308,27 @@ public class MockEntryTest {
   }
 
   @isTest
+  static void testGetParent_WhenParentIsStagedNull_ThenReturnNull() {
+    // A parent explicitly staged as null (setParent(field, null)) means "the parent
+    // record does not exist". Entry.getParent() returns null in the same case, so
+    // MockEntry must behave the same — otherwise the production-side null branch
+    // (if (parent == null) { ... }) can never be covered by a unit test.
+    // Arrange
+    FieldStructure fieldStructure = Scribe.of(Opportunity.class)
+      .parentField(Scribe.asParent('AccountId').field('Name'))
+      .buildFieldStructure();
+    MockEntry mockEntry = (MockEntry) MockEntry.of(Opportunity.class)
+      .setParent('AccountId', null)
+      .setFieldStructure(fieldStructure);
+
+    // Act
+    IEntry parent = mockEntry.getParent('AccountId');
+
+    // Assert
+    Assert.isNull(parent, 'A parent staged as null should be returned as null, matching Entry.getParent().');
+  }
+
+  @isTest
   static void testTemplate_WhenApplyNull_ThenThrowException() {
     // Arrange
     FieldStructure fieldStructure = Scribe.of(Account.class).field('Name').buildFieldStructure();


### PR DESCRIPTION
## Summary
`MockEntry.getParent()` threw a `NullPointerException` when the parent had been explicitly staged as null (`setParent(field, null)`): the `instanceof MockEntry` branch is skipped for null, and `resultEntry.setFieldStructure(...)` then dereferences null.

Production `Entry.getParent()` returns `null` when the parent record does not exist — that is the `IEntry.getParent()` contract. The mock being stricter than production meant the production-side `if (parent == null)` branch could never be covered by a unit test, which is exactly the class of blind spot this library exists to remove.

### Fix
Return `null` for an explicitly staged null parent, matching `Entry`. The guard sits **on top of** the `instanceof MockEntry` skip-validation branch (does not roll it back).

This also fixes the same case reached through `getThrough()` / `getThroughByRelationName()`, which delegate to `getParent(relatedKey)` per junction entry — a junction row with a null related parent now yields a `null` element, as `Entry` does.

### Audit of sibling getters (same mock-stricter-than-production class of bug)
- `getChildren` / `getChildrenByRelationName`: not affected — `setChildren(name, null)` is rejected up front, and a null staged via the deprecated `addChildren` produces a descriptive `ApexEloquentException`, not an NPE
- `getThrough` / `getThroughByRelationName`: fixed transitively by this patch (see above)

## Tests
- New: `testGetParent_WhenParentIsStagedNull_ThenReturnNull` — asserts `getParent` returns null (no exception) for a staged-null parent, matching `Entry.getParent()`
- Full framework suite: **745 tests, 0 failures** against a Developer Edition org

Backport: the identical patch is on the `v2.1.x` maintenance branch for the v2 line (released as v2.1.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)