### PR TITLE
Fix ignoreWhen leaving stale OR-only mode when retracting the only OR condition

### DIFF
--- a/Scribe.cls
+++ b/Scribe.cls
@@ -725,6 +725,17 @@ public with sharing class Scribe {
     Scribe clonedScribe = this.deepClone();
     if (shouldIgnore == true) {
       clonedScribe.conditionParts.remove(clonedScribe.conditionParts.size() - 1);
+      // Recompute the OR-only mode from the remaining parts: when the retracted
+      // condition was the only OR, the chain must accept plain (AND) conditions
+      // again — otherwise the OR marker would outlive its retracted target.
+      Boolean hasOrPart = false;
+      for (ConditionPart part : clonedScribe.conditionParts) {
+        if (part.isOr == true) {
+          hasOrPart = true;
+          break;
+        }
+      }
+      clonedScribe.canOnlyAddOrCondition = hasOrPart;
     }
 
     return clonedScribe;

--- a/tests/ScribeTest.cls
+++ b/tests/ScribeTest.cls
@@ -495,6 +495,75 @@ public with sharing class ScribeTest {
   }
 
   @isTest
+  static void testIgnoreWhen_WhenOrConditionIgnored_ThenSoqlDropsIt() {
+    // Arrange: the OR condition itself is the ignoreWhen target
+    Scribe scribe = Scribe.of(Account.class)
+      .field('Id')
+      .whereEqual('Name', 'A')
+      .orCondition()
+      .whereEqual('Industry', 'B')
+      .ignoreWhen(true);
+
+    // Act
+    String soql = scribe.toSoql();
+
+    // Assert: the ignored OR condition leaves no trace in the SOQL
+    Assert.areEqual('SELECT id FROM Account WHERE Name = \'A\'', soql);
+  }
+
+  @isTest
+  static void testIgnoreWhen_WhenOrConditionIgnored_ThenAndConditionCanFollow() {
+    // Arrange & Act: ignoring the only OR condition must also retract the OR-only mode,
+    // so a plain (AND) condition can follow — the query no longer contains any OR
+    Scribe scribe = Scribe.of(Account.class)
+      .field('Id')
+      .whereEqual('Name', 'A')
+      .orCondition()
+      .whereEqual('Industry', 'B')
+      .ignoreWhen(true)
+      .whereEqual('Phone', 'C');
+
+    // Assert
+    Assert.areEqual('SELECT id FROM Account WHERE Name = \'A\' AND Phone = \'C\'', scribe.toSoql());
+  }
+
+  @isTest
+  static void testIgnoreWhen_WhenOrConditionIgnored_ThenExplicitOrStillWorks() {
+    // Arrange & Act: an explicit orCondition() after the ignore keeps working
+    Scribe scribe = Scribe.of(Account.class)
+      .field('Id')
+      .whereEqual('Name', 'A')
+      .orCondition()
+      .whereEqual('Industry', 'B')
+      .ignoreWhen(true)
+      .orCondition()
+      .whereEqual('Phone', 'C');
+
+    // Assert
+    Assert.areEqual('SELECT id FROM Account WHERE Name = \'A\' OR Phone = \'C\'', scribe.toSoql());
+  }
+
+  @isTest
+  static void testIgnoreWhen_WhenOrConditionRemains_ThenOrOnlyModeIsKept() {
+    // Arrange & Act & Assert: A OR B OR C, ignoring C — an OR part still remains,
+    // so a plain (AND) condition must still be rejected
+    try {
+      Scribe.of(Account.class)
+        .field('Id')
+        .whereEqual('Name', 'A')
+        .orCondition()
+        .whereEqual('Industry', 'B')
+        .orCondition()
+        .whereEqual('Phone', 'C')
+        .ignoreWhen(true)
+        .whereEqual('Fax', 'D');
+      Assert.fail('Expected ApexEloquentException to be thrown');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('orCondition'), e.getMessage());
+    }
+  }
+
+  @isTest
   static void testIgnoreWhen_WhenNoPrecedingCondition_ThenThrows() {
     // Arrange & Act & Assert: ignoreWhen() before any where...() is a structural misuse
     try {


### PR DESCRIPTION
## Bug
`.whereEqual(A).orCondition().whereEqual(B).ignoreWhen(true)` retracts condition B from the query (the built SOQL is correctly `WHERE A`), but `orCondition()`'s `canOnlyAddOrCondition` flag survived the retraction:

1. A subsequent plain `.whereEqual(C)` threw `Illegal Logical Transition` even though the query no longer contains any OR — the OR marker outlived its retracted target
2. Worse: working around that exception by adding `.orCondition()` **silently turned an intended AND into an OR** (`WHERE A OR C`)

This defeats `ignoreWhen`'s purpose (dynamic query building from optional inputs) whenever OR is involved.

## Fix
`ignoreWhen(true)` now recomputes the OR-only mode from the **remaining** condition parts after the removal:
- retracting the only OR part → plain (AND) conditions are accepted again
- retracting the last of several ORs (`A OR B OR C`, ignore C) → an OR part still remains, so the OR-only invariant is kept

## Tests
4 new tests in `ScribeTest` (repro-first: the AND-can-follow test was red before the fix):
- ignored OR leaves no trace in SOQL
- plain AND condition can follow the retraction (the bug)
- explicit `orCondition()` after the retraction still works
- OR-only mode is kept while any OR part remains

Full framework suite: **749 tests, 0 failures**.

Note: `ignoreWhen` is v3-only, so no v2.1.x backport is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)