### PR TITLE
orCondition() degrades to a no-op when no condition exists yet

### DIFF
--- a/Scribe.cls
+++ b/Scribe.cls
@@ -671,7 +671,15 @@ public with sharing class Scribe {
   /**
    * Specifies that the next WHERE condition should be joined with an OR operator.
    *
-   * Cannot be the first condition. Subsequent conditions must also be OR unless grouped.
+   * Subsequent conditions must also be OR unless grouped.
+   *
+   * When no condition exists yet, this is a no-op: with ignoreWhen() dynamically
+   * retracting conditions, "A OR B where A may vanish" is a legitimate chain, and
+   * the surviving condition simply becomes the first (plain) condition:
+   *   scribe.whereIn('X', a).ignoreWhen(a.isEmpty())
+   *         .orCondition()
+   *         .whereIn('Y', b).ignoreWhen(b.isEmpty())
+   *
    * @return A new, immutable Scribe instance configured for an OR condition.
    */
   public Scribe orCondition() {
@@ -680,11 +688,10 @@ public with sharing class Scribe {
 
     Scribe clonedScribe = this.deepClone();
 
+    // No condition to attach to (either never added, or retracted by ignoreWhen):
+    // do not raise the OR marker — the next condition starts the WHERE clause.
     if (clonedScribe.conditionParts.isEmpty() && !clonedScribe.isParent) {
-      String error = 'Invalid Logical Sequence';
-      String reason = 'An OR condition cannot be the starting point of a WHERE clause. It must append to an existing condition.';
-      String action = 'Please call a where...() method (e.g., .whereEqual(), .whereIn()) before invoking .orCondition().';
-      ApexEloquentException.at(CLASS_NAME).method(method).error(error).reason(reason).action(action).fire();
+      return clonedScribe;
     }
     clonedScribe.isNextConditionOr = true;
     clonedScribe.canOnlyAddOrCondition = true;

--- a/tests/ScribeTest.cls
+++ b/tests/ScribeTest.cls
@@ -564,6 +564,67 @@ public with sharing class ScribeTest {
   }
 
   @isTest
+  static void testOrCondition_WhenFirstConditionIgnored_ThenSurvivorIsSoleCondition() {
+    // Arrange & Act: "A OR B" where A is dynamically retracted — the OR degrades
+    // to a no-op and B becomes the sole (plain) condition
+    Scribe scribe = Scribe.of(Account.class)
+      .field('Id')
+      .whereEqual('Name', 'A')
+      .ignoreWhen(true)
+      .orCondition()
+      .whereEqual('Industry', 'B');
+
+    // Assert
+    Assert.areEqual('SELECT id FROM Account WHERE Industry = \'B\'', scribe.toSoql());
+  }
+
+  @isTest
+  static void testOrCondition_WhenBothSidesIgnored_ThenNoWhereClause() {
+    // Arrange & Act: both sides of the OR vanish — no WHERE clause at all
+    Scribe scribe = Scribe.of(Account.class)
+      .field('Id')
+      .whereEqual('Name', 'A')
+      .ignoreWhen(true)
+      .orCondition()
+      .whereEqual('Industry', 'B')
+      .ignoreWhen(true);
+
+    // Assert
+    Assert.areEqual('SELECT id FROM Account', scribe.toSoql());
+  }
+
+  @isTest
+  static void testOrCondition_WhenBothSidesKept_ThenOrQuery() {
+    // Arrange & Act: the branch-free dynamic form with nothing retracted keeps the OR
+    Scribe scribe = Scribe.of(Account.class)
+      .field('Id')
+      .whereEqual('Name', 'A')
+      .ignoreWhen(false)
+      .orCondition()
+      .whereEqual('Industry', 'B')
+      .ignoreWhen(false);
+
+    // Assert
+    Assert.areEqual('SELECT id FROM Account WHERE Name = \'A\' OR Industry = \'B\'', scribe.toSoql());
+  }
+
+  @isTest
+  static void testOrCondition_WhenNoOp_ThenPlainAndCanFollow() {
+    // Arrange & Act: a no-op orCondition() must not raise the OR-only mode —
+    // the survivor is a plain first condition and AND conditions may follow
+    Scribe scribe = Scribe.of(Account.class)
+      .field('Id')
+      .whereEqual('Name', 'A')
+      .ignoreWhen(true)
+      .orCondition()
+      .whereEqual('Industry', 'B')
+      .whereEqual('Phone', 'C');
+
+    // Assert
+    Assert.areEqual('SELECT id FROM Account WHERE Industry = \'B\' AND Phone = \'C\'', scribe.toSoql());
+  }
+
+  @isTest
   static void testIgnoreWhen_WhenNoPrecedingCondition_ThenThrows() {
     // Arrange & Act & Assert: ignoreWhen() before any where...() is a structural misuse
     try {
@@ -1269,17 +1330,14 @@ public with sharing class ScribeTest {
   }
 
   @isTest
-  static void testOrCondition_WhenAddOrConditionAtFirst_ThenThrownException() {
-    // Arrange / Act / Assert
-    try {
-      Scribe scribe = Scribe.of(Account.class).field('Id').orCondition().whereEqual('Name', 'Test Account');
+  static void testOrCondition_WhenAddOrConditionAtFirst_ThenNoOp() {
+    // Arrange / Act: since v3.1.0 a leading orCondition() is a no-op (conditions can
+    // vanish dynamically via ignoreWhen, so "no condition yet" is a legitimate state) —
+    // the following condition simply starts the WHERE clause
+    Scribe scribe = Scribe.of(Account.class).field('Id').orCondition().whereEqual('Name', 'Test Account');
 
-      Assert.fail('Expected ApexEloquentException to be thrown');
-    } catch (ApexEloquentException e) {
-      String error = e.getMessage();
-      Assert.isTrue(error.contains('orCondition()'));
-      Assert.isTrue(error.contains('Invalid Logical Sequence'));
-    }
+    // Assert
+    Assert.areEqual('SELECT id FROM Account WHERE Name = \'Test Account\'', scribe.toSoql());
   }
 
   @isTest


### PR DESCRIPTION
## Motivation
Follow-up to #53 (v3.0.2), proposed from field usage. With `ignoreWhen()` dynamically retracting conditions, this chain still threw:

```apex
.whereIn('NormalizedCompany__c', names).ignoreWhen(names.isEmpty())   // 先頭が消えると…
.orCondition()                                                        // ← Invalid Logical Sequence
.whereIn('SansanCompanyId__c', ids).ignoreWhen(ids.isEmpty())
```

The `cannot be the starting point` guard predates `ignoreWhen` — it caught a static misuse that, in the dynamic era, is indistinguishable from a legitimately emptied condition list, and it forced consumers back into if-branches for optional OR inputs.

## Change
`orCondition()` on an empty condition list is now a **no-op**: no OR marker is raised, the surviving condition simply starts the WHERE clause, and plain (AND) conditions may follow it. Semantics: *"A OR B, where either side may vanish" folds to the survivor as a sole condition* — the natural reading. Consistent with v3.0.2's principle that OR bookkeeping is always derived from the actual condition list.

The above chain is now fully branch-free and covers all four states: both kept → `A OR B`; A retracted → `B`; B retracted → `A` (v3.0.2); both retracted → no WHERE.

## Compatibility
Only affects chains that previously **threw** — no previously-working chain changes meaning. The static misuse `Scribe.of(X).orCondition().where...` now silently yields a valid single-condition query instead of an exception (existing test updated to document this). Minor version bump.

## Tests
4 new + 1 updated in `ScribeTest`: survivor-as-sole-condition, both-sides-vanish (no WHERE), both-sides-kept (OR), no-op does not raise OR-only mode (AND can follow), leading orCondition no-op. Full framework suite: **753 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)