### PR TITLE
MockEloquent: throw on labeled reads against unattached labels

### DIFF
--- a/Eloquents/MockEloquent.cls
+++ b/Eloquents/MockEloquent.cls
@@ -232,11 +232,32 @@ public with sharing class MockEloquent implements IEloquent {
    * query source for the given label. Order of precedence:
    *   1. preloaded via attach(label, ...)
    *   2. legacy MockEloquent(List<IEntry>) entries — only when label == 'default'
-   *   3. empty list
+   *
+   * A labeled read on a label that was never attached is a test-setup bug
+   * (a forgotten or typo'd attach): the query would silently return an empty
+   * list and the zero-row path would pass without verifying anything. In test
+   * context this therefore throws instead (mirroring ApexTrace's automatic
+   * Strict mode). An explicitly attached empty list remains the legitimate
+   * way to declare the zero-row path — "not attached" and "attached empty"
+   * are distinct states.
    */
   private List<IEntry> activeEntries(String label) {
     if (this.attachedDataByLabel.containsKey(label)) {
       return this.attachedDataByLabel.get(label);
+    }
+    if (label != DEFAULT_LABEL && Test.isRunningTest()) {
+      List<String> attachedLabels = new List<String>(this.attachedDataByLabel.keySet());
+      attachedLabels.sort();
+      String reason =
+        'label \'' + label + '\' has no attached entries.\n' +
+        'Attached labels: [' + String.join(attachedLabels, ', ') + ']';
+      String action =
+        'Attach the data for this label, or if you intend to test the zero-row path, ' +
+        'attach an empty list explicitly: .attach(label, new List<IEntry>())';
+      ApexEloquentException.invalidOperation(CLASS_NAME, 'activeEntries(String label)', reason)
+        .action(action)
+        .param('label', label)
+        .fire();
     }
     return label == DEFAULT_LABEL ? this.entries : new List<IEntry>();
   }

--- a/Eloquents/tests/MockEloquentTest.cls
+++ b/Eloquents/tests/MockEloquentTest.cls
@@ -2606,13 +2606,18 @@ public with sharing class MockEloquentTest {
   }
 
   @isTest
-  static void testGet_WhenLabelCalledButNoAttach_ThenReturnEmpty() {
+  static void testGet_WhenLabelCalledButNoAttach_ThenThrows() {
     MockEntry legacy = MockEntry.of(Account.class).autoId(1).set('Name', 'LegacyDefault');
     MockEloquent mock = new MockEloquent(new List<IEntry>{ legacy });
     Scribe scribe = Scribe.of(Account.class).field('Name');
-    // label('opp') has no attach — should NOT fall back to legacy entries
-    List<IEntry> result = mock.label('opp').get(scribe);
-    Assert.areEqual(0, result.size(), 'Non-default label without attach returns empty (no legacy fallback).');
+    // label('opp') has no attach — no legacy fallback, and in test context this is
+    // treated as a test-setup bug (forgotten attach) instead of a silent empty list
+    try {
+      mock.label('opp').get(scribe);
+      Assert.fail('Expected ApexEloquentException for unattached label.');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('has no attached entries'), e.getMessage());
+    }
   }
 
   @isTest
@@ -2627,7 +2632,8 @@ public with sharing class MockEloquentTest {
 
   @isTest
   static void testFirstOrFail_WhenLabelEmpty_ThenThrowException() {
-    MockEloquent mock = new MockEloquent();
+    // The zero-row path is declared explicitly with an attached empty list
+    MockEloquent mock = (new MockEloquent()).attach('opp', new List<IEntry>());
     Scribe scribe = Scribe.of(Account.class).field('Name');
     try {
       mock.label('opp').firstOrFail(scribe);
@@ -2758,11 +2764,14 @@ public with sharing class MockEloquentTest {
 
   @isTest
   static void testFailOnGet_WithWhenLabel_AndLabelMismatch_ThenDoNotFire() {
-    MockEloquent mock = (new MockEloquent()).failOnGet().whenLabel('opp');
+    MockEloquent mock = (new MockEloquent())
+      .attach('quote', new List<IEntry>())
+      .failOnGet()
+      .whenLabel('opp');
     Scribe scribe = Scribe.of(Account.class).field('Name');
     // Calling with a different label should NOT fire the failure
     List<IEntry> result = mock.label('quote').get(scribe);
-    Assert.areEqual(0, result.size(), 'No failure should fire; empty list since quote has no attach.');
+    Assert.areEqual(0, result.size(), 'No failure should fire; quote is attached empty.');
   }
 
   @isTest
@@ -3008,5 +3017,82 @@ public with sharing class MockEloquentTest {
     mock.get(scribe);
     mock.get(scribe);
     Assert.isTrue(true, 'label(null) did not flip strict mode on.');
+  }
+
+  // ===============================================================================
+  // Unattached-label guard (auto-strict in test context)
+  // ===============================================================================
+
+  @isTest
+  static void testGet_WhenLabelNotAttached_ThenThrowsWithAttachedLabelList() {
+    // Arrange - 'byPostal' is never attached (forgotten / typo'd attach)
+    Scribe scribe = Scribe.of(Account.class).field('Id');
+    MockEloquent mock = (new MockEloquent())
+      .attach('byName', new List<IEntry>{ MockEntry.of(Account.class).autoId(1) })
+      .attach('byCompanyId', new List<IEntry>());
+
+    // Act & Assert
+    try {
+      mock.label('byPostal').get(scribe);
+      Assert.fail('Expected ApexEloquentException to be thrown');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('\'byPostal\' has no attached entries'), e.getMessage());
+      Assert.isTrue(e.getMessage().contains('byCompanyId, byName'), e.getMessage());
+      Assert.isTrue(e.getMessage().contains('.attach(label, new List<IEntry>())'), e.getMessage());
+    }
+  }
+
+  @isTest
+  static void testGet_WhenEmptyListAttached_ThenReturnsEmptyWithoutException() {
+    // Arrange - an explicitly attached empty list is the legitimate zero-row declaration
+    Scribe scribe = Scribe.of(Account.class).field('Id');
+    MockEloquent mock = (new MockEloquent()).attach('byName', new List<IEntry>());
+
+    // Act
+    List<IEntry> entries = mock.label('byName').get(scribe);
+
+    // Assert
+    Assert.areEqual(0, entries.size(), 'Attached empty list must stay a valid zero-row path');
+  }
+
+  @isTest
+  static void testFirst_WhenLabelNotAttached_ThenThrows() {
+    // Arrange
+    Scribe scribe = Scribe.of(Account.class).field('Id');
+    MockEloquent mock = (new MockEloquent()).attach('byName', new List<IEntry>());
+
+    // Act & Assert - first() is guarded the same way as get()
+    try {
+      mock.label('byPostal').first(scribe);
+      Assert.fail('Expected ApexEloquentException to be thrown');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('has no attached entries'), e.getMessage());
+    }
+  }
+
+  @isTest
+  static void testDoUpdate_WhenLabelNotAttached_ThenNoException() {
+    // Arrange - DML does not consult attached data, so unattached labels stay legal
+    MockEloquent mock = (new MockEloquent()).attach('byName', new List<IEntry>());
+    Account acc = new Account(Id = MockEntry.of(Account.class).autoId(1).getId(), Name = 'x');
+
+    // Act
+    mock.label('updateAccounts').doUpdate(acc);
+
+    // Assert
+    Assert.areEqual(1, mock.upsertedRecordsAt('updateAccounts').size());
+  }
+
+  @isTest
+  static void testGet_WhenLegacyUnlabeledMode_ThenConstructorEntriesUnchanged() {
+    // Arrange - label-free legacy mode is untouched by the guard
+    Scribe scribe = Scribe.of(Account.class).field('Id');
+    MockEloquent mock = new MockEloquent(new List<IEntry>{ MockEntry.of(Account.class).autoId(1) });
+
+    // Act
+    List<IEntry> entries = mock.get(scribe);
+
+    // Assert
+    Assert.areEqual(1, entries.size());
   }
 }


### PR DESCRIPTION
## Problem (field-reported, author-agreed policy)
A labeled read on a label that was never attached returned an empty list instead of failing:

```apex
MockEloquent mock = new MockEloquent()
  .attach(Usecase.LBL_BY_NAME, new List<IEntry>{ someEntry });
// LBL_BY_POSTAL の attach を忘れた → 例外にならず空が返る → 0件経路として静かに緑
```

The zero-row path passes without verifying anything — the least detectable way for a test to be broken. Similar label names (`matchAccountsByName` / `matchAccountsByPostal`) make the typo/forgotten-attach case realistic.

## Change
Labeled `get` / `first` / `firstOrFail` on an unattached label now **throw** in test context (`Test.isRunningTest()` — automatic strict, mirroring ApexTrace; no opt-in). The guard lives in the single read-path chokepoint (`activeEntries`), so DML methods are untouched.

The error message directs the next action and makes typos visible:

```
label 'byPostal' has no attached entries.
Attached labels: [byCompanyId, byName]
Action: Attach the data for this label, or if you intend to test the zero-row path,
        attach an empty list explicitly: .attach(label, new List<IEntry>())
```

**Preserved invariants** (the two conditions from the request):
- "not attached" vs "attached empty" stay distinct states — `.attach(label, new List<IEntry>())` remains the legitimate zero-row declaration (explicit test)
- unlabeled legacy mode (constructor entries, no label()) unchanged
- DML (`doInsert/doUpdate/doUpsert/doDelete`) with any label unchanged (explicit test)

## Impact
Consumer tests that were green due to a forgotten attach will now fail — that is the discovery of an existing defect, not a break. Fix is one of: attach the intended data, or declare the zero-row path with an explicit empty attach. Three of this framework's own tests codified the old silent-empty behavior and were updated.

## Tests
5 new tests (unattached→throw with label list / attached-empty→ok / first guarded / DML unaffected / legacy mode unaffected) + 3 updated. Full suite: **758 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)