### PR TITLE
Add firstOrFail(Scribe, Exception) overload

### DIFF
--- a/Eloquents/Eloquent.cls
+++ b/Eloquents/Eloquent.cls
@@ -238,6 +238,27 @@ public inherited sharing class Eloquent implements IEloquent {
   /**
    * @inheritDoc
    */
+  public IEntry firstOrFail(Scribe scribe, Exception orFail) {
+    String label = this.consumeLabel();
+    String method = ('firstOrFail(Scribe scribe, Exception orFail)');
+    if (scribe == null) {
+      ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
+    }
+    if (orFail == null) {
+      ApexEloquentException.required(CLASS_NAME, method, 'orFail', null).fire();
+    }
+
+    List<SObject> records = (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
+
+    if (records.isEmpty()) {
+      throw orFail;
+    }
+    return new Entry(records[0]);
+  }
+
+  /**
+   * @inheritDoc
+   */
   public SObject firstOrFailAsSObject(Scribe scribe) {
     String label = this.consumeLabel();
     String method = ('firstOrFailAsSObject(Scribe scribe)');

--- a/Eloquents/IEloquent.cls
+++ b/Eloquents/IEloquent.cls
@@ -109,6 +109,18 @@ public interface IEloquent {
   IEntry firstOrFail(Scribe scribe);
 
   /**
+  * Executes SOQL and returns the first record.
+  * If the number of retrieved records is 0, the given exception is thrown as-is —
+  * business-specific errors (e.g. UsecaseException with a user-facing message)
+  * no longer need the first() + null-check + throw boilerplate.
+  *
+  * @param Scribe scribe: Scribe instance containing the SOQL query
+  * @param Exception orFail: the exception to throw when zero records are found
+  * @return Retrieved result as an Entry object
+  */
+  IEntry firstOrFail(Scribe scribe, Exception orFail);
+
+  /**
   * Executes SOQL and returns the first record as SObject.
   * If the number of retrieved records is 0, an exception is thrown.
   *

--- a/Eloquents/MockEloquent.cls
+++ b/Eloquents/MockEloquent.cls
@@ -435,6 +435,30 @@ public with sharing class MockEloquent implements IEloquent {
   /**
    * @inheritDoc
    */
+  public IEntry firstOrFail(Scribe scribe, Exception orFail) {
+    String method = 'firstOrFail(Scribe scribe, Exception orFail)';
+    String label = this.consumeLabel();
+    this.handleErrorQueue(method, label);
+    if (scribe == null) {
+      ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
+    }
+    if (orFail == null) {
+      ApexEloquentException.required(CLASS_NAME, method, 'orFail', null).fire();
+    }
+
+    this.scribe = scribe;
+    String soql = scribe.toSoql(); // for showing and validate SOQL
+    FieldStructure fieldStructure = scribe.buildFieldStructure();
+    List<IEntry> source = this.activeEntries(label);
+    if (source.isEmpty()) {
+      throw orFail;
+    }
+    return source[0].setFieldStructure(fieldStructure);
+  }
+
+  /**
+   * @inheritDoc
+   */
   public SObject firstOrFailAsSObject(Scribe scribe) {
     String method = 'firstOrFailAsSObject(Scribe scribe)';
     String label = this.consumeLabel();

--- a/Eloquents/tests/EloquentTest.cls
+++ b/Eloquents/tests/EloquentTest.cls
@@ -1462,4 +1462,48 @@ public with sharing class EloquentTest {
       Assert.isTrue(e.getMessage().contains('retrieved via SOQL'), e.getMessage());
     }
   }
+
+  private class RoundTripNotFoundException extends Exception {
+  }
+
+  @isTest
+  static void testFirstOrFail_WhenCustomExceptionAndRowExists_ThenReturnsEntry() {
+    // Arrange
+    Group grp = buildGroup('fofCustomHit');
+    insert grp;
+
+    // Act
+    Scribe groupScribe = Scribe.of(Group.class).field('Id').whereEqual('Id', grp.Id);
+    IEntry entry = (new Eloquent()).firstOrFail(groupScribe, new RoundTripNotFoundException('not used'));
+
+    // Assert
+    Assert.areEqual(grp.Id, entry.getId());
+  }
+
+  @isTest
+  static void testFirstOrFail_WhenCustomExceptionAndNoRow_ThenThrowsItAsIs() {
+    // Arrange - a query that matches nothing
+    Scribe groupScribe = Scribe.of(Group.class)
+      .field('Id')
+      .whereEqual('DeveloperName', 'EloquentRT_never_exists_' + Datetime.now().getTime());
+
+    // Act & Assert - the given exception is thrown as-is (type and message preserved)
+    try {
+      (new Eloquent()).firstOrFail(groupScribe, new RoundTripNotFoundException('business-facing message'));
+      Assert.fail('Expected RoundTripNotFoundException to be thrown');
+    } catch (RoundTripNotFoundException e) {
+      Assert.areEqual('business-facing message', e.getMessage());
+    }
+  }
+
+  @isTest
+  static void testFirstOrFail_WhenCustomExceptionIsNull_ThenThrowsRequired() {
+    // Act & Assert
+    try {
+      (new Eloquent()).firstOrFail(Scribe.of(Group.class).field('Id'), null);
+      Assert.fail('Expected ApexEloquentException to be thrown');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('The `orFail` argument is required'), e.getMessage());
+    }
+  }
 }

--- a/Eloquents/tests/MockEloquentTest.cls
+++ b/Eloquents/tests/MockEloquentTest.cls
@@ -3095,4 +3095,50 @@ public with sharing class MockEloquentTest {
     // Assert
     Assert.areEqual(1, entries.size());
   }
+
+  private class MockNotFoundException extends Exception {
+  }
+
+  @isTest
+  static void testFirstOrFail_WhenCustomExceptionAndEntryAttached_ThenReturnsEntry() {
+    // Arrange
+    MockEntry grpEntry = MockEntry.of(Account.class).autoId(1).set('Name', 'Hit');
+    MockEloquent mock = (new MockEloquent()).attach('fetch', new List<IEntry>{ grpEntry });
+    Scribe scribe = Scribe.of(Account.class).field('Id').field('Name');
+
+    // Act
+    IEntry result = mock.label('fetch').firstOrFail(scribe, new MockNotFoundException('not used'));
+
+    // Assert
+    Assert.areEqual('Hit', result.get('Name'));
+  }
+
+  @isTest
+  static void testFirstOrFail_WhenCustomExceptionAndEmptyAttached_ThenThrowsItAsIs() {
+    // Arrange - the zero-row path is declared with an explicit empty attach
+    MockEloquent mock = (new MockEloquent()).attach('fetch', new List<IEntry>());
+    Scribe scribe = Scribe.of(Account.class).field('Id');
+
+    // Act & Assert - the given exception is thrown as-is (type and message preserved)
+    try {
+      mock.label('fetch').firstOrFail(scribe, new MockNotFoundException('business-facing message'));
+      Assert.fail('Expected MockNotFoundException to be thrown');
+    } catch (MockNotFoundException e) {
+      Assert.areEqual('business-facing message', e.getMessage());
+    }
+  }
+
+  @isTest
+  static void testFirstOrFail_WhenCustomExceptionIsNull_ThenThrowsRequired() {
+    // Arrange
+    MockEloquent mock = (new MockEloquent()).attach('fetch', new List<IEntry>());
+
+    // Act & Assert
+    try {
+      mock.label('fetch').firstOrFail(Scribe.of(Account.class).field('Id'), null);
+      Assert.fail('Expected ApexEloquentException to be thrown');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('The `orFail` argument is required'), e.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
Implements #50.

```apex
IEntry card = this.eloquent.label(LBL_CARD)
  .firstOrFail(cardQuery, new UsecaseException('名刺が見つかりません'));
```

Zero rows → the given exception is thrown **as-is** (type and message preserved), collapsing the `first()` + null check + throw boilerplate. Implemented on `IEloquent` / `Eloquent` / `MockEloquent` — the mock throws it for an explicitly-attached empty list, so the zero-row business-error path unit-tests naturally (composes with the v3.2.0 unattached-label guard, which fires first for forgotten attaches).

Note: interface addition — external `IEloquent` implementers must add the method (release note). No `AsSObject` variant (consistent with the getAsSObject-discouraged policy).

Tests: 6 new (real: hit / zero-row as-is / null guard; mock: same trio). EloquentTest + MockEloquentTest: **242 tests, 0 failures**.

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)