### PR TITLE
Add MockEntry.fetchedBy(Scribe) for Batch-type SELECT contracts

### DIFF
--- a/Entries/MockEntry.cls
+++ b/Entries/MockEntry.cls
@@ -1223,6 +1223,36 @@ public with sharing class MockEntry extends AbstractEntry {
   }
 
   /**
+   * Declares that this MockEntry represents a record fetched by the given Scribe:
+   * the Scribe's SELECT contract (fields and relations) is baked in, so any read
+   * outside the contract fails exactly as it would for a real query result.
+   *
+   * Designed for directly-injected entries — e.g. Batch usecases whose input is
+   * List<IEntry>. Share the same Scribe as the Batchable's start() (typically a
+   * @TestVisible static scope() method) so the SELECT truth has a single source:
+   *
+   * <pre>
+   * MockEntry card = MockEntry.of(BusinessCard__c.class)
+   *   .autoId(1)
+   *   .set('CompanyName__c', 'Acme')
+   *   .fetchedBy(CardSyncBatch.scope());
+   * </pre>
+   *
+   * FieldStructure is a mock-side strictness tool: production Entry needs none,
+   * because a real SOQL row already throws on unqueried field access.
+   *
+   * @param scribe The Scribe whose SELECT contract this entry was fetched under.
+   * @return A new MockEntry carrying the contract.
+   */
+  public MockEntry fetchedBy(Scribe scribe) {
+    String method = 'fetchedBy(Scribe scribe)';
+    if (scribe == null) {
+      ApexEloquentException.required(CLASS_NAME, method, 'scribe', scribe).fire();
+    }
+    return (MockEntry) this.setFieldStructure(scribe.buildFieldStructure());
+  }
+
+  /**
    * validate the field name.
    *
    * @param fieldName field name to be validated

--- a/Entries/tests/MockEntryTest.cls
+++ b/Entries/tests/MockEntryTest.cls
@@ -2826,4 +2826,77 @@ public class MockEntryTest {
       Assert.isTrue(e.getMessage().contains('Account'), 'Error should mention Account SObject.');
     }
   }
+
+  // ===============================================================================
+  // fetchedBy: bake a Scribe's SELECT contract into a directly-injected entry (issue #48)
+  // ===============================================================================
+
+  @isTest
+  static void testFetchedBy_WhenFieldInContract_ThenReadable() {
+    // Arrange - the same Scribe a Batchable's start() would use
+    Scribe scope = Scribe.of(Account.class).field('Id').field('Name');
+    MockEntry entry = MockEntry.of(Account.class).autoId(1).set('Name', 'Acme').fetchedBy(scope);
+
+    // Act & Assert
+    Assert.areEqual('Acme', entry.get('Name'));
+  }
+
+  @isTest
+  static void testFetchedBy_WhenFieldOutsideContract_ThenThrows() {
+    // Arrange - Industry is set on the mock but NOT selected by the Scribe
+    Scribe scope = Scribe.of(Account.class).field('Id').field('Name');
+    MockEntry entry = MockEntry.of(Account.class).autoId(1).set('Industry', 'Tech').fetchedBy(scope);
+
+    // Act & Assert - reads outside the contract fail like a real query result would
+    try {
+      entry.get('Industry');
+      Assert.fail('Expected ApexEloquentException for a field outside the SELECT contract');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('Industry'), e.getMessage());
+    }
+  }
+
+  @isTest
+  static void testFetchedBy_WhenParentRelationInContract_ThenParentReadable() {
+    // Arrange - the contract includes the parent relation, so getParent round-trips
+    Scribe scope = Scribe.of(Opportunity.class)
+      .field('Id')
+      .parentField(Scribe.asParent('AccountId').field('Name'));
+    MockEntry entry = MockEntry.of(Opportunity.class)
+      .autoId(1)
+      .setParent('AccountId', MockEntry.of(Account.class).set('Name', 'Parent Co.'))
+      .fetchedBy(scope);
+
+    // Act & Assert
+    Assert.areEqual('Parent Co.', entry.getParent('AccountId').get('Name'));
+  }
+
+  @isTest
+  static void testFetchedBy_WhenParentRelationOutsideContract_ThenThrows() {
+    // Arrange - the contract has no parent relation at all
+    Scribe scope = Scribe.of(Opportunity.class).field('Id');
+    MockEntry entry = MockEntry.of(Opportunity.class)
+      .autoId(1)
+      .setParent('AccountId', MockEntry.of(Account.class).set('Name', 'Parent Co.'))
+      .fetchedBy(scope);
+
+    // Act & Assert
+    try {
+      entry.getParent('AccountId');
+      Assert.fail('Expected ApexEloquentException for a relation outside the SELECT contract');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('AccountId'), e.getMessage());
+    }
+  }
+
+  @isTest
+  static void testFetchedBy_WhenScribeIsNull_ThenThrowsRequired() {
+    // Act & Assert
+    try {
+      MockEntry.of(Account.class).fetchedBy(null);
+      Assert.fail('Expected ApexEloquentException to be thrown');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('The `scribe` argument is required'), e.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
Implements #48 (final design after three review rounds: IEloquent.wrap → IEntry+Entry validation → **MockEntry-only**).

```apex
MockEntry card = MockEntry.of(BusinessCard__c.class)
  .autoId(1)
  .set('CompanyName__c', 'Acme')
  .fetchedBy(CardSyncBatch.scope());   // ← start() と同じ @TestVisible static Scribe を共有
```

- **Reads outside the contract fail** exactly like a real query result — the Batch-type gap (SELECT contract lost at the QueryLocator boundary) closes without `withoutFieldValidation()` and without hand-built lowercase FieldStructure lists
- Relations bake too: `parentField` in the Scribe → `getParent` round-trips; absent → throws
- **MockEntry-only by design**: FieldStructure is a mock-side strictness tool. Production `Entry` needs none — a real SOQL row already throws on unqueried access (documented by EloquentTest's real-row test). No empty methods on `Entry`, no `IEntry`/`IEloquent` changes, zero breaking surface
- Naming: `fetchedBy` = provenance declaration ("この Scribe で取得されたことにする"), consistent with the LBL_FETCH vocabulary and ApexBlueprint's `sharedWith` style

Tests: 5 new (in-contract read / out-of-contract read throws / parent relation in & out / null guard). MockEntryTest: **146 tests, 0 failures**.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)