### PR TITLE
Fix copy() dropping saveErrorsById: failSave survives failOnXxx/repeat chains

### DIFF
--- a/Eloquents/MockEloquent.cls
+++ b/Eloquents/MockEloquent.cls
@@ -1258,6 +1258,7 @@ public with sharing class MockEloquent implements IEloquent {
     newMockEloquent.attachedDataByLabel = new Map<String, List<IEntry>>(this.attachedDataByLabel);
     newMockEloquent.upsertedByLabel = new Map<String, List<SObject>>(this.upsertedByLabel);
     newMockEloquent.deletedCountByLabel = new Map<String, Integer>(this.deletedCountByLabel);
+    newMockEloquent.saveErrorsById = new Map<Id, String>(this.saveErrorsById);
     // strict mode state must propagate so failOnXxx-induced copies still enforce
     // consume-once across the original "intent boundary" (issue_39).
     newMockEloquent.strictMode = this.strictMode;

--- a/Eloquents/tests/MockEloquentTest.cls
+++ b/Eloquents/tests/MockEloquentTest.cls
@@ -3231,4 +3231,37 @@ public with sharing class MockEloquentTest {
       Assert.isTrue(e.getMessage().contains('The `errorMessage` argument is required'), e.getMessage());
     }
   }
+
+  @isTest
+  static void testFailSave_ThenFailOn_ThenSaveErrorSurvives() {
+    // Arrange - failSave registered BEFORE a copy()-returning failOnXxx (issue #61):
+    // copy() must carry saveErrorsById, or the registration silently vanishes
+    Account bad = new Account(Id = MockEntry.of(Account.class).autoId(1).getId(), Name = 'bad');
+    MockEloquent mock = (new MockEloquent())
+      .failSave(bad.Id, 'no')
+      .failOnGet(new QueryException('unrelated'));
+
+    // Act
+    Database.SaveResult result = mock.doUpdate((SObject) bad, false);
+
+    // Assert
+    Assert.isFalse(result.isSuccess(), 'failSave registration must survive the failOnXxx copy()');
+    Assert.areEqual('no', result.getErrors()[0].getMessage());
+  }
+
+  @isTest
+  static void testFailOn_ThenFailSave_ThenSaveErrorSurvives() {
+    // Arrange - reverse order: failSave mutates the instance returned by failOnXxx
+    Account bad = new Account(Id = MockEntry.of(Account.class).autoId(1).getId(), Name = 'bad');
+    MockEloquent mock = (new MockEloquent())
+      .failOnGet(new QueryException('unrelated'))
+      .failSave(bad.Id, 'no');
+
+    // Act
+    Database.SaveResult result = mock.doUpdate((SObject) bad, false);
+
+    // Assert
+    Assert.isFalse(result.isSuccess());
+    Assert.areEqual('no', result.getErrors()[0].getMessage());
+  }
 }


### PR DESCRIPTION
Closes #61

## What
`copy()` carries entries / errorQueueMap / attachedDataByLabel / upsertedByLabel / deletedCountByLabel / strictMode / consumedLabels — but not `saveErrorsById`. Since `failOnXxx()` and `repeat()` route through `copy()`, a `failSave()` registered before them in the chain silently vanished:

```apex
// ❌ lost:  (new MockEloquent()).failSave(badId, 'no').failOnDoUpdate(ex);
// ✅ works: (new MockEloquent()).failOnDoUpdate(ex).failSave(badId, 'no');
```

## Fix
One line in `copy()`: `newMockEloquent.saveErrorsById = new Map<Id, String>(this.saveErrorsById);`

## Tests
Both chain orders now assert the failed SaveResult survives:
- `testFailSave_ThenFailOn_ThenSaveErrorSurvives` (red before this fix)
- `testFailOn_ThenFailSave_ThenSaveErrorSurvives`

MockEloquentTest: 174 tests, 0 failures on a Developer Edition org.

After merge: backport to `v2.2.x` (code is identical there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)