### PR TITLE
Unify builder immutability: attach/failSave/whenLabel return copies

### DIFF
--- a/Eloquents/MockEloquent.cls
+++ b/Eloquents/MockEloquent.cls
@@ -142,14 +142,18 @@ public with sharing class MockEloquent implements IEloquent {
   /**
    * Pre-load data for a label. Subsequent read calls tagged with that label
    * will see this data as the query source. Overwrites prior attach.
+   *
+   * Returns a new instance (the receiver is unmodified), like every test-setup
+   * builder on this class — always use the return value.
    */
   public MockEloquent attach(String label, List<IEntry> entries) {
     if (label == null || String.isBlank(label)) {
       ApexEloquentException.required(CLASS_NAME, 'attach(String label, List<IEntry> entries)', 'label', label)
         .fire();
     }
-    this.attachedDataByLabel.put(label, entries == null ? new List<IEntry>() : entries);
-    return this;
+    MockEloquent newMockEloquent = this.copy();
+    newMockEloquent.attachedDataByLabel.put(label, entries == null ? new List<IEntry>() : entries);
+    return newMockEloquent;
   }
 
   /**
@@ -169,6 +173,9 @@ public with sharing class MockEloquent implements IEloquent {
    * mirroring real all-or-nothing DML.
    *
    * The target is identified by record Id — pair with MockEntry.autoId().
+   *
+   * Returns a new instance (the receiver is unmodified), like every test-setup
+   * builder on this class — always use the return value.
    */
   public MockEloquent failSave(Id recordId, String errorMessage) {
     String method = 'failSave(Id recordId, String errorMessage)';
@@ -178,8 +185,9 @@ public with sharing class MockEloquent implements IEloquent {
     if (String.isBlank(errorMessage)) {
       ApexEloquentException.required(CLASS_NAME, method, 'errorMessage', errorMessage).fire();
     }
-    this.saveErrorsById.put(recordId, errorMessage);
-    return this;
+    MockEloquent newMockEloquent = this.copy();
+    newMockEloquent.saveErrorsById.put(recordId, errorMessage);
+    return newMockEloquent;
   }
 
   /**
@@ -202,6 +210,9 @@ public with sharing class MockEloquent implements IEloquent {
    * Scopes the most recently configured failOnXxx to a label. Reads as
    * "fail on get when label is 'opp'". Same modifier pattern as repeat().
    *
+   * Returns a new instance (the receiver is unmodified), like every test-setup
+   * builder on this class — always use the return value.
+   *
    * @throws ApexEloquentException if called without a preceding failOnXxx()
    */
   public MockEloquent whenLabel(String label) {
@@ -210,8 +221,10 @@ public with sharing class MockEloquent implements IEloquent {
       String action = 'Call failOnGet() / failOnDoInsert() / etc. before calling whenLabel(...).';
       ApexEloquentException.invalidOperation(CLASS_NAME, 'whenLabel(String label)', reason).action(action).fire();
     }
-    this.lastConfig.label = label;
-    return this;
+    // copy() maps this.lastConfig to its clone on the new instance
+    MockEloquent newMockEloquent = this.copy();
+    newMockEloquent.lastConfig.label = label;
+    return newMockEloquent;
   }
 
   /**

--- a/Eloquents/tests/MockEloquentTest.cls
+++ b/Eloquents/tests/MockEloquentTest.cls
@@ -2539,10 +2539,13 @@ public with sharing class MockEloquentTest {
   }
 
   @isTest
-  static void testAttach_WhenChained_ThenReturnSelf() {
+  static void testAttach_WhenChained_ThenReturnCopyCarryingAttachment() {
+    // Since issue #63, attach() returns a new instance (builder immutability);
+    // the returned copy carries the attachment, the receiver stays untouched
     MockEloquent mock = new MockEloquent();
     MockEloquent result = mock.attach('foo', new List<IEntry>());
-    Assert.areEqual(mock, result);
+    Assert.areNotEqual(mock, result, 'attach() must return a copy, not the receiver');
+    Assert.areEqual(0, result.label('foo').get(Scribe.of(Account.class).field('Id')).size());
   }
 
   @isTest
@@ -3263,5 +3266,62 @@ public with sharing class MockEloquentTest {
     // Assert
     Assert.isFalse(result.isSuccess());
     Assert.areEqual('no', result.getErrors()[0].getMessage());
+  }
+
+  // ===============================================================================
+  // Builder immutability: attach / failSave / whenLabel return copies (issue #63)
+  // ===============================================================================
+
+  @isTest
+  static void testAttach_ReturnsCopy_AndReceiverIsUnmodified() {
+    // Arrange
+    MockEloquent original = new MockEloquent();
+    MockEloquent configured = original.attach(
+      'fetch',
+      new List<IEntry>{ MockEntry.of(Account.class).autoId(1) }
+    );
+    Scribe scribe = Scribe.of(Account.class).field('Id');
+
+    // Assert - the returned instance sees the attached data
+    Assert.areEqual(1, configured.label('fetch').get(scribe).size());
+
+    // Assert - the receiver never learned the label: strict unattached-label read throws
+    try {
+      original.label('fetch').get(scribe);
+      Assert.fail('Expected ApexEloquentException: label must not leak into the receiver');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('fetch'), e.getMessage());
+    }
+  }
+
+  @isTest
+  static void testFailSave_ReturnsCopy_AndReceiverIsUnmodified() {
+    // Arrange
+    Account bad = new Account(Id = MockEntry.of(Account.class).autoId(1).getId(), Name = 'bad');
+    MockEloquent original = new MockEloquent();
+    MockEloquent configured = original.failSave(bad.Id, 'no');
+
+    // Assert - the returned instance fails the record, the receiver still succeeds
+    Assert.isFalse(configured.doUpdate((SObject) bad, false).isSuccess());
+    Assert.isTrue(original.doUpdate((SObject) bad, false).isSuccess());
+  }
+
+  @isTest
+  static void testWhenLabel_ReturnsCopy_AndReceiverIsUnmodified() {
+    // Arrange
+    MockEloquent withFail = (new MockEloquent()).failOnGet(new QueryException('boom'));
+    MockEloquent scoped = withFail.whenLabel('opp');
+    Scribe scribe = Scribe.of(Account.class).field('Name');
+
+    // Assert - on the scoped instance the config targets 'opp', so a plain get does not fire
+    Assert.areEqual(0, scoped.get(scribe).size());
+
+    // Assert - the receiver's config is still unscoped and fires on a plain get
+    try {
+      withFail.get(scribe);
+      Assert.fail('Expected QueryException: whenLabel must not leak into the receiver');
+    } catch (QueryException e) {
+      Assert.areEqual('boom', e.getMessage());
+    }
   }
 }


### PR DESCRIPTION
Closes #63

## What
The test-setup builders were split between two mutability models:

| method | before |
|---|---|
| `attach` / `failSave` / `whenLabel` | mutate `this`, return `this` |
| `failOnXxx` / `repeat` | return a `copy()` |

Discarding the return value therefore worked for some builders and silently no-op'd for others. Scribe / MockEntry are uniformly immutable; this brings MockEloquent's test-setup surface in line: **all of attach / failSave / whenLabel now return a new instance.**

Out of scope (intentionally `this`-mutating): `label()` (never reassigned at call sites — `this.eloquent.label(X).get(scribe)` — and copying would break consume-once tracking) and `userMode()` / `systemMode()` (sticky per-instance by design).

## ⚠️ Behavior change
Statement-style calls that discard the return (`mock.attach('x', entries);`) no longer take effect — chain or reassign instead. The framework's own tests had no such call sites; downstream projects should grep for statement-style `attach(` / `failSave(` / `whenLabel(` before upgrading.

`testAttach_WhenChained_ThenReturnSelf` codified the old contract and was rewritten to `testAttach_WhenChained_ThenReturnCopyCarryingAttachment`.

## Tests
- `testAttach_ReturnsCopy_AndReceiverIsUnmodified`
- `testFailSave_ReturnsCopy_AndReceiverIsUnmodified`
- `testWhenLabel_ReturnsCopy_AndReceiverIsUnmodified`

MockEloquentTest: 177 tests, 0 failures on a Developer Edition org.

After merge: backport to `v2.2.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)