### PR TITLE
Per-label FIFO error queues + release labels on failure (consume-once = one success per label)

### DIFF
--- a/Eloquents/Eloquent.cls
+++ b/Eloquents/Eloquent.cls
@@ -76,7 +76,8 @@ public inherited sharing class Eloquent implements IEloquent {
    * Captures the current label for routing/logging, resets the transient
    * label state, and enforces strict-mode rules:
    *   (1) once strict mode is active, every operation must be preceded by .label(...)
-   *   (2) each label can be consumed at most once per IEloquent instance
+   *   (2) each label allows at most one SUCCESSFUL operation per IEloquent instance
+   *       (a failed operation releases its label so the attempt can be retried)
    */
   private String consumeLabel() {
     String label = this.currentLabel;
@@ -100,7 +101,7 @@ public inherited sharing class Eloquent implements IEloquent {
     }
     if (this.consumedLabels.contains(label)) {
       String reason = 'Label \'' + label + '\' has already been consumed on this IEloquent instance.';
-      String action = 'Each label can be used at most once per IEloquent. Use a different label name, or construct a fresh IEloquent.';
+      String action = 'A label allows at most one successful operation per IEloquent (failed attempts may be retried). Use a different label name, or construct a fresh IEloquent.';
       ApexEloquentException.invalidOperation(CLASS_NAME, 'label(String label) [consume-once]', reason)
         .action(action)
         .param('label', label)
@@ -114,25 +115,39 @@ public inherited sharing class Eloquent implements IEloquent {
   }
 
   /**
+   * Releases a label whose operation failed. consume-once guards one
+   * SUCCESSFUL operation per label — a failed attempt did not fulfill the
+   * label's intent, so the same label may be retried.
+   */
+  private void releaseLabel(String label) {
+    this.consumedLabels.remove(label);
+  }
+
+  /**
    * @inheritDoc
    */
   public List<IEntry> get(Scribe scribe) {
     String label = this.consumeLabel();
-    String method = ('get(Scribe scribe)');
-    if (scribe == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'sctibe', null).fire();
-    }
+    try {
+      String method = ('get(Scribe scribe)');
+      if (scribe == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'sctibe', null).fire();
+      }
 
-    if (scribe.isAggregate()) {
-      return this.getAggregate(scribe);
-    }
+      if (scribe.isAggregate()) {
+        return this.getAggregate(scribe);
+      }
 
-    List<IEntry> entries = new List<IEntry>();
-    for (SObject record : (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel)) {
-      entries.add(new Entry(record));
-    }
+      List<IEntry> entries = new List<IEntry>();
+      for (SObject record : (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel)) {
+        entries.add(new Entry(record));
+      }
 
-    return entries;
+      return entries;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   private List<IEntry> getAggregate(Scribe scribe) {
@@ -150,15 +165,20 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public List<IEntry> rawSoql(String soql) {
     String label = this.consumeLabel();
-    String method = 'rawSoql(String soql)';
-    if (String.isBlank(soql)) {
-      ApexEloquentException.required(CLASS_NAME, method, 'soql', soql).fire();
+    try {
+      String method = 'rawSoql(String soql)';
+      if (String.isBlank(soql)) {
+        ApexEloquentException.required(CLASS_NAME, method, 'soql', soql).fire();
+      }
+      List<IEntry> entries = new List<IEntry>();
+      for (SObject record : (List<SObject>) Database.query(soql, this.accessLevel)) {
+        entries.add(new Entry(record));
+      }
+      return entries;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    List<IEntry> entries = new List<IEntry>();
-    for (SObject record : (List<SObject>) Database.query(soql, this.accessLevel)) {
-      entries.add(new Entry(record));
-    }
-    return entries;
   }
 
   /**
@@ -166,12 +186,17 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public List<SObject> getAsSObject(Scribe scribe) {
     String label = this.consumeLabel();
-    String method = ('getAsSObject(Scribe scribe)');
-    if (scribe == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
-    }
+    try {
+      String method = ('getAsSObject(Scribe scribe)');
+      if (scribe == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
+      }
 
-    return (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
+      return (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -179,16 +204,21 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public IEntry first(Scribe scribe) {
     String label = this.consumeLabel();
-    String method = ('first(Scribe scribe)');
-    if (scribe == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
-    }
+    try {
+      String method = ('first(Scribe scribe)');
+      if (scribe == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
+      }
 
-    List<SObject> records = (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
-    if (records.isEmpty()) {
-      return null;
+      List<SObject> records = (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
+      if (records.isEmpty()) {
+        return null;
+      }
+      return new Entry(records[0]);
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return new Entry(records[0]);
   }
 
   /**
@@ -196,16 +226,21 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public SObject firstAsSObject(Scribe scribe) {
     String label = this.consumeLabel();
-    String method = ('firstAsSObject(Scribe scribe)');
-    if (scribe == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
-    }
+    try {
+      String method = ('firstAsSObject(Scribe scribe)');
+      if (scribe == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
+      }
 
-    List<SObject> records = (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
-    if (records.isEmpty()) {
-      return null;
+      List<SObject> records = (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
+      if (records.isEmpty()) {
+        return null;
+      }
+      return records[0];
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return records[0];
   }
 
   /**
@@ -213,26 +248,31 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public IEntry firstOrFail(Scribe scribe) {
     String label = this.consumeLabel();
-    String method = ('firstOrFail(Scribe scribe)');
-    if (scribe == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
-    }
+    try {
+      String method = ('firstOrFail(Scribe scribe)');
+      if (scribe == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
+      }
 
-    List<SObject> records = (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
+      List<SObject> records = (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
 
-    if (records.isEmpty()) {
-      String error = 'No records were found for the given criteria';
-      String reason = 'The query execution returned zero records';
-      String action = 'Ensure that the query criteria are correct and that relevant records exist in the database';
-      ApexEloquentException.at(CLASS_NAME)
-        .method(method)
-        .error(error)
-        .reason(reason)
-        .action(action)
-        .param('SOQL', scribe.toSoql())
-        .fire();
+      if (records.isEmpty()) {
+        String error = 'No records were found for the given criteria';
+        String reason = 'The query execution returned zero records';
+        String action = 'Ensure that the query criteria are correct and that relevant records exist in the database';
+        ApexEloquentException.at(CLASS_NAME)
+          .method(method)
+          .error(error)
+          .reason(reason)
+          .action(action)
+          .param('SOQL', scribe.toSoql())
+          .fire();
+      }
+      return new Entry(records[0]);
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return new Entry(records[0]);
   }
 
   /**
@@ -240,20 +280,25 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public IEntry firstOrFail(Scribe scribe, Exception orFail) {
     String label = this.consumeLabel();
-    String method = ('firstOrFail(Scribe scribe, Exception orFail)');
-    if (scribe == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
-    }
-    if (orFail == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'orFail', null).fire();
-    }
+    try {
+      String method = ('firstOrFail(Scribe scribe, Exception orFail)');
+      if (scribe == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
+      }
+      if (orFail == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'orFail', null).fire();
+      }
 
-    List<SObject> records = (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
+      List<SObject> records = (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
 
-    if (records.isEmpty()) {
-      throw orFail;
+      if (records.isEmpty()) {
+        throw orFail;
+      }
+      return new Entry(records[0]);
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return new Entry(records[0]);
   }
 
   /**
@@ -261,25 +306,30 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public SObject firstOrFailAsSObject(Scribe scribe) {
     String label = this.consumeLabel();
-    String method = ('firstOrFailAsSObject(Scribe scribe)');
-    if (scribe == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
-    }
+    try {
+      String method = ('firstOrFailAsSObject(Scribe scribe)');
+      if (scribe == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
+      }
 
-    List<SObject> records = (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
-    if (records.isEmpty()) {
-      String error = 'No records were found for the given criteria';
-      String reason = 'The query execution returned zero records';
-      String action = 'Ensure that the query criteria are correct and that relevant records exist in the database';
-      ApexEloquentException.at(CLASS_NAME)
-        .method(method)
-        .error(error)
-        .reason(reason)
-        .action(action)
-        .param('SOQL', scribe.toSoql())
-        .fire();
+      List<SObject> records = (List<SObject>) Database.query(scribe.toSoql(), this.accessLevel);
+      if (records.isEmpty()) {
+        String error = 'No records were found for the given criteria';
+        String reason = 'The query execution returned zero records';
+        String action = 'Ensure that the query criteria are correct and that relevant records exist in the database';
+        ApexEloquentException.at(CLASS_NAME)
+          .method(method)
+          .error(error)
+          .reason(reason)
+          .action(action)
+          .param('SOQL', scribe.toSoql())
+          .fire();
+      }
+      return records[0];
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return records[0];
   }
 
   /**
@@ -287,17 +337,22 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public SObject doInsert(SObject record) {
     String label = this.consumeLabel();
-    String method = ('doInsert(SObject record)');
-    if (record == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'record', record).fire();
-    }
     try {
-      Database.insert(record, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('insert', e);
-      ex.method(method).param('record', record).fire();
+      String method = ('doInsert(SObject record)');
+      if (record == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'record', record).fire();
+      }
+      try {
+        Database.insert(record, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('insert', e);
+        ex.method(method).param('record', record).fire();
+      }
+      return record;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return record;
   }
 
   /**
@@ -305,18 +360,23 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public List<SObject> doInsert(List<SObject> records) {
     String label = this.consumeLabel();
-    String method = ('doInsert(List<SObject> records)');
-    if (records == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
-    }
-    sortToPreventChunkingErrors(records);
     try {
-      Database.insert(records, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('insert', e);
-      ex.method(method).param('records', records).fire();
+      String method = ('doInsert(List<SObject> records)');
+      if (records == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
+      }
+      sortToPreventChunkingErrors(records);
+      try {
+        Database.insert(records, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('insert', e);
+        ex.method(method).param('records', records).fire();
+      }
+      return records;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return records;
   }
 
   /**
@@ -324,18 +384,23 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public SObject doUpdate(SObject record) {
     String label = this.consumeLabel();
-    String method = ('doUpdate(SObject record)');
-    if (record == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
-    }
-
     try {
-      Database.update(record, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('update', e);
-      ex.method(method).param('record', record).fire();
+      String method = ('doUpdate(SObject record)');
+      if (record == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
+      }
+
+      try {
+        Database.update(record, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('update', e);
+        ex.method(method).param('record', record).fire();
+      }
+      return record;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return record;
   }
 
   /**
@@ -343,19 +408,24 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public Database.SaveResult doUpdate(SObject record, Boolean allOrNone) {
     String label = this.consumeLabel();
-    String method = ('doUpdate(SObject record, Boolean allOrNone)');
-    if (record == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
-    }
-
     try {
-      return Database.update(record, allOrNone, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('update', e);
-      ex.method(method).param('record', record).param('allOrNone', allOrNone).fire();
-    }
+      String method = ('doUpdate(SObject record, Boolean allOrNone)');
+      if (record == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
+      }
 
-    return null;
+      try {
+        return Database.update(record, allOrNone, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('update', e);
+        ex.method(method).param('record', record).param('allOrNone', allOrNone).fire();
+      }
+
+      return null;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -363,18 +433,23 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public IEntry doUpdate(IEntry entry) {
     String label = this.consumeLabel();
-    String method = ('doUpdate(IEntry entry)');
-    if (entry == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
-    }
-    SObject record = entry.getRecord();
     try {
-      Database.update(record, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('update', e);
-      ex.method(method).param('entry', entry).fire();
+      String method = ('doUpdate(IEntry entry)');
+      if (entry == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
+      }
+      SObject record = entry.getRecord();
+      try {
+        Database.update(record, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('update', e);
+        ex.method(method).param('entry', entry).fire();
+      }
+      return new Entry(record);
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return new Entry(record);
   }
 
   /**
@@ -382,19 +457,24 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public Database.SaveResult doUpdate(IEntry entry, Boolean allOrNone) {
     String label = this.consumeLabel();
-    String method = ('doUpdate(IEntry entry, Boolean allOrNone)');
-    if (entry == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
-    }
-    SObject record = entry.getRecord();
     try {
-      return Database.update(record, allOrNone, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('update', e);
-      ex.method(method).param('entry', entry).param('allOrNone', allOrNone).fire();
-    }
+      String method = ('doUpdate(IEntry entry, Boolean allOrNone)');
+      if (entry == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
+      }
+      SObject record = entry.getRecord();
+      try {
+        return Database.update(record, allOrNone, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('update', e);
+        ex.method(method).param('entry', entry).param('allOrNone', allOrNone).fire();
+      }
 
-    return null;
+      return null;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -402,18 +482,23 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public List<SObject> doUpdate(List<SObject> records) {
     String label = this.consumeLabel();
-    String method = ('doUpdate(List<SObject> records)');
-    if (records == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
-    }
-    sortToPreventChunkingErrors(records);
     try {
-      Database.update(records, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('update', e);
-      ex.method(method).param('records', records).fire();
+      String method = ('doUpdate(List<SObject> records)');
+      if (records == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
+      }
+      sortToPreventChunkingErrors(records);
+      try {
+        Database.update(records, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('update', e);
+        ex.method(method).param('records', records).fire();
+      }
+      return records;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return records;
   }
 
   /**
@@ -421,19 +506,24 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public List<Database.SaveResult> doUpdate(List<SObject> records, Boolean allOrNone) {
     String label = this.consumeLabel();
-    String method = ('doUpdate(List<SObject> records, Boolean allOrNone)');
-    if (records == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
-    }
-    sortToPreventChunkingErrors(records);
     try {
-      return Database.update(records, allOrNone, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('update', e);
-      ex.method(method).param('records', records).param('allOrNone', allOrNone).fire();
-    }
+      String method = ('doUpdate(List<SObject> records, Boolean allOrNone)');
+      if (records == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
+      }
+      sortToPreventChunkingErrors(records);
+      try {
+        return Database.update(records, allOrNone, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('update', e);
+        ex.method(method).param('records', records).param('allOrNone', allOrNone).fire();
+      }
     
-    return null;
+      return null;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -441,30 +531,35 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public List<IEntry> doUpdate(List<IEntry> entries) {
     String label = this.consumeLabel();
-    String method = ('doUpdate(List<IEntry> entries)');
-    if (entries == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
-    }
-
-    if (entries.isEmpty()) {
-      return new List<IEntry>();
-    }
-    List<SObject> records = new List<SObject>();
-    for (IEntry entry : entries) {
-      records.add(entry.getRecord());
-    }
-    sortToPreventChunkingErrors(records);
     try {
-      Database.update(records, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('update', e);
-      ex.method(method).param('entries', entries).fire();
+      String method = ('doUpdate(List<IEntry> entries)');
+      if (entries == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
+      }
+
+      if (entries.isEmpty()) {
+        return new List<IEntry>();
+      }
+      List<SObject> records = new List<SObject>();
+      for (IEntry entry : entries) {
+        records.add(entry.getRecord());
+      }
+      sortToPreventChunkingErrors(records);
+      try {
+        Database.update(records, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('update', e);
+        ex.method(method).param('entries', entries).fire();
+      }
+      List<IEntry> updatedEntries = new List<IEntry>();
+      for (SObject record : records) {
+        updatedEntries.add(new Entry(record));
+      }
+      return updatedEntries;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    List<IEntry> updatedEntries = new List<IEntry>();
-    for (SObject record : records) {
-      updatedEntries.add(new Entry(record));
-    }
-    return updatedEntries;
   }
 
   /**
@@ -472,27 +567,32 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public List<Database.SaveResult> doUpdate(List<IEntry> entries, Boolean allOrNone) {
     String label = this.consumeLabel();
-    String method = ('doUpdate(List<IEntry> entries, Boolean allOrNone)');
-    if (entries == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
-    }
-
-    if (entries.isEmpty()) {
-      return new List<Database.SaveResult>();
-    }
-    List<SObject> records = new List<SObject>();
-    for (IEntry entry : entries) {
-      records.add(entry.getRecord());
-    }
-    sortToPreventChunkingErrors(records);
     try {
-      return Database.update(records, allOrNone, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('update', e);
-      ex.method(method).param('entries', entries).param('allOrNone', allOrNone).fire();
-    }
+      String method = ('doUpdate(List<IEntry> entries, Boolean allOrNone)');
+      if (entries == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
+      }
 
-    return null;
+      if (entries.isEmpty()) {
+        return new List<Database.SaveResult>();
+      }
+      List<SObject> records = new List<SObject>();
+      for (IEntry entry : entries) {
+        records.add(entry.getRecord());
+      }
+      sortToPreventChunkingErrors(records);
+      try {
+        return Database.update(records, allOrNone, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('update', e);
+        ex.method(method).param('entries', entries).param('allOrNone', allOrNone).fire();
+      }
+
+      return null;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -500,18 +600,23 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public SObject doUpsert(SObject record) {
     String label = this.consumeLabel();
-    String method = ('doUpsert(SObject record)');
-    if (record == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
-    }
-
     try {
-      Database.upsert(record, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('upsert', e);
-      ex.method(method).param('record', record).fire();
+      String method = ('doUpsert(SObject record)');
+      if (record == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
+      }
+
+      try {
+        Database.upsert(record, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('upsert', e);
+        ex.method(method).param('record', record).fire();
+      }
+      return record;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return record;
   }
 
   /**
@@ -519,19 +624,24 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public IEntry doUpsert(IEntry entry) {
     String label = this.consumeLabel();
-    String method = ('doUpsert(IEntry entry)');
-    if (entry == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
-    }
-
-    SObject record = entry.getRecord();
     try {
-      Database.upsert(record, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('upsert', e);
-      ex.method(method).param('entry', entry).fire();
+      String method = ('doUpsert(IEntry entry)');
+      if (entry == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
+      }
+
+      SObject record = entry.getRecord();
+      try {
+        Database.upsert(record, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('upsert', e);
+        ex.method(method).param('entry', entry).fire();
+      }
+      return new Entry(record);
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return new Entry(record);
   }
 
   /**
@@ -539,19 +649,24 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public List<SObject> doUpsert(List<SObject> records) {
     String label = this.consumeLabel();
-    String method = ('doUpsert(List<SObject> records)');
-    if (records == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
-    }
-
-    sortToPreventChunkingErrors(records);
     try {
-      Database.upsert(records, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('upsert', e);
-      ex.method(method).param('records', records).fire();
+      String method = ('doUpsert(List<SObject> records)');
+      if (records == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
+      }
+
+      sortToPreventChunkingErrors(records);
+      try {
+        Database.upsert(records, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('upsert', e);
+        ex.method(method).param('records', records).fire();
+      }
+      return records;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return records;
   }
 
   /**
@@ -559,30 +674,35 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public List<IEntry> doUpsert(List<IEntry> entries) {
     String label = this.consumeLabel();
-    String method = ('doUpsert(List<IEntry> entries)');
-    if (entries == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
-    }
-
-    if (entries.isEmpty()) {
-      return new List<IEntry>();
-    }
-    List<SObject> records = new List<SObject>();
-    for (IEntry entry : entries) {
-      records.add(entry.getRecord());
-    }
-    sortToPreventChunkingErrors(records);
     try {
-      Database.upsert(records, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('upsert', e);
-      ex.method(method).param('entries', entries).fire();
+      String method = ('doUpsert(List<IEntry> entries)');
+      if (entries == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
+      }
+
+      if (entries.isEmpty()) {
+        return new List<IEntry>();
+      }
+      List<SObject> records = new List<SObject>();
+      for (IEntry entry : entries) {
+        records.add(entry.getRecord());
+      }
+      sortToPreventChunkingErrors(records);
+      try {
+        Database.upsert(records, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('upsert', e);
+        ex.method(method).param('entries', entries).fire();
+      }
+      List<IEntry> upsertedEntries = new List<IEntry>();
+      for (SObject record : records) {
+        upsertedEntries.add(new Entry(record));
+      }
+      return upsertedEntries;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    List<IEntry> upsertedEntries = new List<IEntry>();
-    for (SObject record : records) {
-      upsertedEntries.add(new Entry(record));
-    }
-    return upsertedEntries;
   }
 
   /**
@@ -590,19 +710,24 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public Database.UpsertResult doUpsertByExternalId(SObject record, Schema.SObjectField externalIdField, Boolean allOrNone) {
     String label = this.consumeLabel();
-    String method = ('doUpsertByExternalId(SObject record, Schema.SObjectField externalIdField, Boolean allOrNone)');
-    if (record == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
-    }
-
     try {
-      return Database.upsert(record, externalIdField, allOrNone, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('upsert', e);
-      ex.method(method).param('record', record).param('externalIdField', externalIdField).param('allOrNone', allOrNone).fire();
-    }
+      String method = ('doUpsertByExternalId(SObject record, Schema.SObjectField externalIdField, Boolean allOrNone)');
+      if (record == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
+      }
 
-    return null;
+      try {
+        return Database.upsert(record, externalIdField, allOrNone, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('upsert', e);
+        ex.method(method).param('record', record).param('externalIdField', externalIdField).param('allOrNone', allOrNone).fire();
+      }
+
+      return null;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -610,20 +735,25 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public Database.UpsertResult doUpsertByExternalId(IEntry entry, Schema.SObjectField externalIdField, Boolean allOrNone) {
     String label = this.consumeLabel();
-    String method = ('doUpsertByExternalId(IEntry entry, Schema.SObjectField externalIdField, Boolean allOrNone)');
-    if (entry == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
-    }
-
-    SObject record = entry.getRecord();
     try {
-      return Database.upsert(record, externalIdField, allOrNone, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('upsert', e);
-      ex.method(method).param('entry', entry).param('externalIdField', externalIdField).param('allOrNone', allOrNone).fire();
-    }
+      String method = ('doUpsertByExternalId(IEntry entry, Schema.SObjectField externalIdField, Boolean allOrNone)');
+      if (entry == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
+      }
 
-    return null;
+      SObject record = entry.getRecord();
+      try {
+        return Database.upsert(record, externalIdField, allOrNone, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('upsert', e);
+        ex.method(method).param('entry', entry).param('externalIdField', externalIdField).param('allOrNone', allOrNone).fire();
+      }
+
+      return null;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -631,20 +761,25 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public List<Database.UpsertResult> doUpsertByExternalId(List<SObject> records, Schema.SObjectField externalIdField, Boolean allOrNone) {
     String label = this.consumeLabel();
-    String method = ('doUpsertByExternalId(List<SObject> records, Schema.SObjectField externalIdField, Boolean allOrNone)');
-    if (records == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
-    }
-
-    sortToPreventChunkingErrors(records);
     try {
-      return Database.upsert(records, externalIdField, allOrNone, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('upsert', e);
-      ex.method(method).param('records', records).param('externalIdField', externalIdField).param('allOrNone', allOrNone).fire();
-    }
+      String method = ('doUpsertByExternalId(List<SObject> records, Schema.SObjectField externalIdField, Boolean allOrNone)');
+      if (records == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
+      }
 
-    return null;
+      sortToPreventChunkingErrors(records);
+      try {
+        return Database.upsert(records, externalIdField, allOrNone, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('upsert', e);
+        ex.method(method).param('records', records).param('externalIdField', externalIdField).param('allOrNone', allOrNone).fire();
+      }
+
+      return null;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -652,27 +787,32 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public List<Database.UpsertResult> doUpsertByExternalId(List<IEntry> entries, Schema.SObjectField externalIdField, Boolean allOrNone) {
     String label = this.consumeLabel();
-    String method = ('doUpsertByExternalId(List<IEntry> entries, Schema.SObjectField externalIdField, Boolean allOrNone)');
-    if (entries == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
-    }
-
-    if (entries.isEmpty()) {
-      return new List<Database.UpsertResult>();
-    }
-    List<SObject> records = new List<SObject>();
-    for (IEntry entry : entries) {
-      records.add(entry.getRecord());
-    }
-    sortToPreventChunkingErrors(records);
     try {
-      return Database.upsert(records, externalIdField, allOrNone, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('upsert', e);
-      ex.method(method).param('entries', entries).param('externalIdField', externalIdField).param('allOrNone', allOrNone).fire();
-    }
+      String method = ('doUpsertByExternalId(List<IEntry> entries, Schema.SObjectField externalIdField, Boolean allOrNone)');
+      if (entries == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
+      }
 
-    return null;
+      if (entries.isEmpty()) {
+        return new List<Database.UpsertResult>();
+      }
+      List<SObject> records = new List<SObject>();
+      for (IEntry entry : entries) {
+        records.add(entry.getRecord());
+      }
+      sortToPreventChunkingErrors(records);
+      try {
+        return Database.upsert(records, externalIdField, allOrNone, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('upsert', e);
+        ex.method(method).param('entries', entries).param('externalIdField', externalIdField).param('allOrNone', allOrNone).fire();
+      }
+
+      return null;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -680,16 +820,21 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public void doDelete(SObject record) {
     String label = this.consumeLabel();
-    String method = ('doDelete(SObject record)');
-    if (record == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
-    }
-
     try {
-      Database.delete(record, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('delete', e);
-      ex.method(method).param('record', record).fire();
+      String method = ('doDelete(SObject record)');
+      if (record == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
+      }
+
+      try {
+        Database.delete(record, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('delete', e);
+        ex.method(method).param('record', record).fire();
+      }
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
   }
 
@@ -698,16 +843,21 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public void doDelete(IEntry entry) {
     String label = this.consumeLabel();
-    String method = ('doDelete(IEntry entry)');
-    if (entry == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
-    }
-
     try {
-      Database.delete(entry.getRecord(), this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('delete', e);
-      ex.method(method).param('entry', entry).fire();
+      String method = ('doDelete(IEntry entry)');
+      if (entry == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
+      }
+
+      try {
+        Database.delete(entry.getRecord(), this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('delete', e);
+        ex.method(method).param('entry', entry).fire();
+      }
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
   }
 
@@ -716,16 +866,21 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public void doDelete(List<SObject> records) {
     String label = this.consumeLabel();
-    String method = ('doDelete(List<SObject> records)');
-    if (records == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
-    }
-
     try {
-      Database.delete(records, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('delete', e);
-      ex.method(method).param('records', records).fire();
+      String method = ('doDelete(List<SObject> records)');
+      if (records == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
+      }
+
+      try {
+        Database.delete(records, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('delete', e);
+        ex.method(method).param('records', records).fire();
+      }
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
   }
 
@@ -734,25 +889,30 @@ public inherited sharing class Eloquent implements IEloquent {
    */
   public void doDelete(List<IEntry> entries) {
     String label = this.consumeLabel();
-    String method = ('doDelete(List<IEntry> entries)');
-    if (entries == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
-    }
-
-    if (entries.isEmpty()) {
-      System.debug('No entries to delete.');
-      return;
-    }
-    List<SObject> records = new List<SObject>();
-    for (IEntry entry : entries) {
-      records.add(entry.getRecord());
-    }
-
     try {
-      Database.delete(records, this.accessLevel);
-    } catch (DmlException e) {
-      ApexEloquentException ex = createDMLException('delete', e);
-      ex.method(method).param('entries', entries).fire();
+      String method = ('doDelete(List<IEntry> entries)');
+      if (entries == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
+      }
+
+      if (entries.isEmpty()) {
+        System.debug('No entries to delete.');
+        return;
+      }
+      List<SObject> records = new List<SObject>();
+      for (IEntry entry : entries) {
+        records.add(entry.getRecord());
+      }
+
+      try {
+        Database.delete(records, this.accessLevel);
+      } catch (DmlException e) {
+        ApexEloquentException ex = createDMLException('delete', e);
+        ex.method(method).param('entries', entries).fire();
+      }
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
   }
 

--- a/Eloquents/MockEloquent.cls
+++ b/Eloquents/MockEloquent.cls
@@ -210,16 +210,36 @@ public with sharing class MockEloquent implements IEloquent {
    * Scopes the most recently configured failOnXxx to a label. Reads as
    * "fail on get when label is 'opp'". Same modifier pattern as repeat().
    *
+   * Failures on one method form a FIFO queue per label: two failOnGet(...)
+   * .whenLabel('opp') configs fire in insertion order on successive 'opp'
+   * reads, and .repeat() makes a labeled failure fire on every attempt.
+   *
    * Returns a new instance (the receiver is unmodified), like every test-setup
    * builder on this class — always use the return value.
    *
-   * @throws ApexEloquentException if called without a preceding failOnXxx()
+   * @throws ApexEloquentException if called without a preceding failOnXxx(),
+   *         with a blank label, or with the reserved 'default' label (a
+   *         failOnXxx without whenLabel(...) already targets 'default')
    */
   public MockEloquent whenLabel(String label) {
+    String method = 'whenLabel(String label)';
+    if (label == null || String.isBlank(label)) {
+      ApexEloquentException.required(CLASS_NAME, method, 'label', label).fire();
+    }
+    if (label == DEFAULT_LABEL) {
+      String reason =
+        'whenLabel(\'' +
+        DEFAULT_LABEL +
+        '\') is redundant: a failOnXxx registered without whenLabel(...) already targets the \'' +
+        DEFAULT_LABEL +
+        '\' label.';
+      String action = 'Drop the whenLabel(...) call, or scope the failure to a real label.';
+      ApexEloquentException.invalidOperation(CLASS_NAME, method, reason).action(action).fire();
+    }
     if (this.lastConfig == null) {
       String reason = 'No failOnXxx to scope. whenLabel() modifies the most recently configured failure.';
       String action = 'Call failOnGet() / failOnDoInsert() / etc. before calling whenLabel(...).';
-      ApexEloquentException.invalidOperation(CLASS_NAME, 'whenLabel(String label)', reason).action(action).fire();
+      ApexEloquentException.invalidOperation(CLASS_NAME, method, reason).action(action).fire();
     }
     // copy() maps this.lastConfig to its clone on the new instance
     MockEloquent newMockEloquent = this.copy();
@@ -231,7 +251,8 @@ public with sharing class MockEloquent implements IEloquent {
    * Captures the current label for routing, resets the transient label state,
    * and enforces strict-mode rules:
    *   (1) once strict mode is active, every operation must be preceded by .label(...)
-   *   (2) each label can be consumed at most once per MockEloquent instance
+   *   (2) each label allows at most one SUCCESSFUL operation per MockEloquent instance
+   *       (a failed operation releases its label so the attempt can be retried)
    */
   private String consumeLabel() {
     String label = this.currentLabel;
@@ -255,7 +276,7 @@ public with sharing class MockEloquent implements IEloquent {
     }
     if (this.consumedLabels.contains(label)) {
       String reason = 'Label \'' + label + '\' has already been consumed on this MockEloquent instance.';
-      String action = 'Each label can be used at most once per MockEloquent. Use a different label name, or construct a fresh MockEloquent.';
+      String action = 'A label allows at most one successful operation per MockEloquent (failed attempts may be retried). Use a different label name, or construct a fresh MockEloquent.';
       ApexEloquentException.invalidOperation(CLASS_NAME, 'label(String label) [consume-once]', reason)
         .action(action)
         .param('label', label)
@@ -263,6 +284,15 @@ public with sharing class MockEloquent implements IEloquent {
     }
     this.consumedLabels.add(label);
     return label;
+  }
+
+  /**
+   * Releases a label whose operation failed. consume-once guards one
+   * SUCCESSFUL operation per label — a failed attempt did not fulfill the
+   * label's intent, so the same label may be retried.
+   */
+  private void releaseLabel(String label) {
+    this.consumedLabels.remove(label);
   }
 
   /**
@@ -337,21 +367,26 @@ public with sharing class MockEloquent implements IEloquent {
   public List<IEntry> get(Scribe scribe) {
     String method = 'get(Scribe scribe)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (scribe == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'sctibe', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (scribe == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'sctibe', null).fire();
+      }
 
-    this.scribe = scribe;
-    String soql = scribe.toSoql(); // for showing and validate SOQL
-    FieldStructure fieldStructure = scribe.isAggregate()
-      ? scribe.buildAggregateFieldStructure()
-      : scribe.buildFieldStructure();
-    List<IEntry> result = new List<IEntry>();
-    for (IEntry entry : this.activeEntries(label)) {
-      result.add(entry.setFieldStructure(fieldStructure));
+      this.scribe = scribe;
+      String soql = scribe.toSoql(); // for showing and validate SOQL
+      FieldStructure fieldStructure = scribe.isAggregate()
+        ? scribe.buildAggregateFieldStructure()
+        : scribe.buildFieldStructure();
+      List<IEntry> result = new List<IEntry>();
+      for (IEntry entry : this.activeEntries(label)) {
+        result.add(entry.setFieldStructure(fieldStructure));
+      }
+      return result;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return result;
   }
 
   /**
@@ -360,23 +395,28 @@ public with sharing class MockEloquent implements IEloquent {
   public List<IEntry> rawSoql(String soql) {
     String method = 'rawSoql(String soql)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (String.isBlank(soql)) {
-      ApexEloquentException.required(CLASS_NAME, method, 'soql', soql).fire();
-    }
-    // Raw SOQL bypasses the Scribe FieldStructure pipeline, so we cannot apply
-    // "select-forgotten detection" to the mocked rows. For MockEntry instances,
-    // turn off skipFieldValidation so callers can read any field; non-MockEntry
-    // entries pass through unchanged.
-    List<IEntry> result = new List<IEntry>();
-    for (IEntry entry : this.activeEntries(label)) {
-      if (entry instanceof MockEntry) {
-        result.add(((MockEntry) entry).withoutFieldValidation());
-      } else {
-        result.add(entry);
+    try {
+      this.handleErrorQueue(method, label);
+      if (String.isBlank(soql)) {
+        ApexEloquentException.required(CLASS_NAME, method, 'soql', soql).fire();
       }
+      // Raw SOQL bypasses the Scribe FieldStructure pipeline, so we cannot apply
+      // "select-forgotten detection" to the mocked rows. For MockEntry instances,
+      // turn off skipFieldValidation so callers can read any field; non-MockEntry
+      // entries pass through unchanged.
+      List<IEntry> result = new List<IEntry>();
+      for (IEntry entry : this.activeEntries(label)) {
+        if (entry instanceof MockEntry) {
+          result.add(((MockEntry) entry).withoutFieldValidation());
+        } else {
+          result.add(entry);
+        }
+      }
+      return result;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return result;
   }
 
   /**
@@ -385,18 +425,23 @@ public with sharing class MockEloquent implements IEloquent {
   public List<SObject> getAsSObject(Scribe scribe) {
     String method = 'getAsSObject(Scribe scribe)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (scribe == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'sctibe', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (scribe == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'sctibe', null).fire();
+      }
 
-    this.scribe = scribe;
-    String soql = scribe.toSoql(); // for showing and validate SOQL
-    List<SObject> result = new List<SObject>();
-    for (IEntry entry : this.activeEntries(label)) {
-      result.add(entry.getRecord());
+      this.scribe = scribe;
+      String soql = scribe.toSoql(); // for showing and validate SOQL
+      List<SObject> result = new List<SObject>();
+      for (IEntry entry : this.activeEntries(label)) {
+        result.add(entry.getRecord());
+      }
+      return result;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return result;
   }
 
   /**
@@ -405,19 +450,24 @@ public with sharing class MockEloquent implements IEloquent {
   public IEntry first(Scribe scribe) {
     String method = 'first(Scribe scribe)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (scribe == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'sctibe', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (scribe == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'sctibe', null).fire();
+      }
 
-    this.scribe = scribe;
-    String soql = scribe.toSoql(); // for showing and validate SOQL
-    FieldStructure fieldStructure = scribe.buildFieldStructure();
-    List<IEntry> source = this.activeEntries(label);
-    if (source.isEmpty()) {
-      return null;
+      this.scribe = scribe;
+      String soql = scribe.toSoql(); // for showing and validate SOQL
+      FieldStructure fieldStructure = scribe.buildFieldStructure();
+      List<IEntry> source = this.activeEntries(label);
+      if (source.isEmpty()) {
+        return null;
+      }
+      return source[0].setFieldStructure(fieldStructure);
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return source[0].setFieldStructure(fieldStructure);
   }
 
   /**
@@ -426,18 +476,23 @@ public with sharing class MockEloquent implements IEloquent {
   public SObject firstAsSObject(Scribe scribe) {
     String method = 'firstAsSObject(Scribe scribe)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (scribe == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'sctibe', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (scribe == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'sctibe', null).fire();
+      }
 
-    this.scribe = scribe;
-    String soql = scribe.toSoql(); // for showing and validate SOQL
-    List<IEntry> source = this.activeEntries(label);
-    if (source.isEmpty()) {
-      return null;
+      this.scribe = scribe;
+      String soql = scribe.toSoql(); // for showing and validate SOQL
+      List<IEntry> source = this.activeEntries(label);
+      if (source.isEmpty()) {
+        return null;
+      }
+      return source[0].getRecord();
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return source[0].getRecord();
   }
 
   /**
@@ -446,28 +501,33 @@ public with sharing class MockEloquent implements IEloquent {
   public IEntry firstOrFail(Scribe scribe) {
     String method = 'firstOrFail(Scribe scribe)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (scribe == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'sctibe', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (scribe == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'sctibe', null).fire();
+      }
 
-    this.scribe = scribe;
-    String soql = scribe.toSoql(); // for showing and validate SOQL
-    FieldStructure fieldStructure = scribe.buildFieldStructure();
-    List<IEntry> source = this.activeEntries(label);
-    if (source.isEmpty()) {
-      String error = 'No records were found for the given criteria';
-      String reason = 'The query execution returned zero records';
-      String action = 'Ensure the test data is correctly registered in MockEloquent';
-      ApexEloquentException.at(CLASS_NAME)
-        .method(method)
-        .error(error)
-        .reason(reason)
-        .action(action)
-        .param('SOQL', scribe.toSoql())
-        .fire();
+      this.scribe = scribe;
+      String soql = scribe.toSoql(); // for showing and validate SOQL
+      FieldStructure fieldStructure = scribe.buildFieldStructure();
+      List<IEntry> source = this.activeEntries(label);
+      if (source.isEmpty()) {
+        String error = 'No records were found for the given criteria';
+        String reason = 'The query execution returned zero records';
+        String action = 'Ensure the test data is correctly registered in MockEloquent';
+        ApexEloquentException.at(CLASS_NAME)
+          .method(method)
+          .error(error)
+          .reason(reason)
+          .action(action)
+          .param('SOQL', scribe.toSoql())
+          .fire();
+      }
+      return source[0].setFieldStructure(fieldStructure);
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return source[0].setFieldStructure(fieldStructure);
   }
 
   /**
@@ -476,22 +536,27 @@ public with sharing class MockEloquent implements IEloquent {
   public IEntry firstOrFail(Scribe scribe, Exception orFail) {
     String method = 'firstOrFail(Scribe scribe, Exception orFail)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (scribe == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
-    }
-    if (orFail == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'orFail', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (scribe == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'scribe', null).fire();
+      }
+      if (orFail == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'orFail', null).fire();
+      }
 
-    this.scribe = scribe;
-    String soql = scribe.toSoql(); // for showing and validate SOQL
-    FieldStructure fieldStructure = scribe.buildFieldStructure();
-    List<IEntry> source = this.activeEntries(label);
-    if (source.isEmpty()) {
-      throw orFail;
+      this.scribe = scribe;
+      String soql = scribe.toSoql(); // for showing and validate SOQL
+      FieldStructure fieldStructure = scribe.buildFieldStructure();
+      List<IEntry> source = this.activeEntries(label);
+      if (source.isEmpty()) {
+        throw orFail;
+      }
+      return source[0].setFieldStructure(fieldStructure);
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return source[0].setFieldStructure(fieldStructure);
   }
 
   /**
@@ -500,27 +565,32 @@ public with sharing class MockEloquent implements IEloquent {
   public SObject firstOrFailAsSObject(Scribe scribe) {
     String method = 'firstOrFailAsSObject(Scribe scribe)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (scribe == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'sctibe', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (scribe == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'sctibe', null).fire();
+      }
 
-    this.scribe = scribe;
-    String soql = scribe.toSoql(); // for showing and validate SOQL
-    List<IEntry> source = this.activeEntries(label);
-    if (source.isEmpty()) {
-      String error = 'No records were found for the given criteria';
-      String reason = 'The query execution returned zero records';
-      String action = 'Ensure the test data is correctly registered in MockEloquent';
-      ApexEloquentException.at(CLASS_NAME)
-        .method(method)
-        .error(error)
-        .reason(reason)
-        .action(action)
-        .param('SOQL', scribe.toSoql())
-        .fire();
+      this.scribe = scribe;
+      String soql = scribe.toSoql(); // for showing and validate SOQL
+      List<IEntry> source = this.activeEntries(label);
+      if (source.isEmpty()) {
+        String error = 'No records were found for the given criteria';
+        String reason = 'The query execution returned zero records';
+        String action = 'Ensure the test data is correctly registered in MockEloquent';
+        ApexEloquentException.at(CLASS_NAME)
+          .method(method)
+          .error(error)
+          .reason(reason)
+          .action(action)
+          .param('SOQL', scribe.toSoql())
+          .fire();
+      }
+      return source[0].getRecord();
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return source[0].getRecord();
   }
 
   /**
@@ -529,14 +599,19 @@ public with sharing class MockEloquent implements IEloquent {
   public SObject doInsert(SObject record) {
     String method = 'doInsert(SObject record)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (record == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'record', record).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (record == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'record', record).fire();
+      }
 
-    record.Id = this.generateId(record);
-    this.recordUpsert(label, record);
-    return record;
+      record.Id = this.generateId(record);
+      this.recordUpsert(label, record);
+      return record;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -545,15 +620,20 @@ public with sharing class MockEloquent implements IEloquent {
   public List<SObject> doInsert(List<SObject> records) {
     String method = 'doInsert(List<SObject> records)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (records == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
+    try {
+      this.handleErrorQueue(method, label);
+      if (records == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
+      }
+      for (SObject record : records) {
+        record.Id = this.generateId(record);
+      }
+      this.recordUpsertAll(label, records);
+      return records;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    for (SObject record : records) {
-      record.Id = this.generateId(record);
-    }
-    this.recordUpsertAll(label, records);
-    return records;
   }
 
   /**
@@ -562,13 +642,18 @@ public with sharing class MockEloquent implements IEloquent {
   public SObject doUpdate(SObject record) {
     String method = 'doUpdate(SObject record)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (record == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (record == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
+      }
 
-    this.recordUpsert(label, record);
-    return record;
+      this.recordUpsert(label, record);
+      return record;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -577,13 +662,18 @@ public with sharing class MockEloquent implements IEloquent {
   public IEntry doUpdate(IEntry entry) {
     String method = 'doUpdate(IEntry entry)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (entry == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (entry == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
+      }
 
-    this.recordUpsert(label, entry.getRecord());
-    return entry;
+      this.recordUpsert(label, entry.getRecord());
+      return entry;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -592,13 +682,18 @@ public with sharing class MockEloquent implements IEloquent {
   public List<SObject> doUpdate(List<SObject> records) {
     String method = 'doUpdate(List<SObject> records)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (records == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (records == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
+      }
 
-    this.recordUpsertAll(label, records);
-    return records;
+      this.recordUpsertAll(label, records);
+      return records;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -607,16 +702,21 @@ public with sharing class MockEloquent implements IEloquent {
   public List<IEntry> doUpdate(List<IEntry> entries) {
     String method = 'doUpdate(List<IEntry> entries)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (entries == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (entries == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
+      }
 
-    for (IEntry entry : entries) {
-      this.recordUpsert(label, entry.getRecord());
-    }
+      for (IEntry entry : entries) {
+        this.recordUpsert(label, entry.getRecord());
+      }
 
-    return entries;
+      return entries;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -625,18 +725,23 @@ public with sharing class MockEloquent implements IEloquent {
   public Database.SaveResult doUpdate(SObject record, Boolean allOrNone) {
     String method = 'doUpdate(SObject record, Boolean allOrNone)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (record == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (record == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
+      }
 
-    if (allOrNone == true) {
-      this.enforceAllOrNone(method, record);
+      if (allOrNone == true) {
+        this.enforceAllOrNone(method, record);
+      }
+      if (!this.isSaveFailure(record)) {
+        this.recordUpsert(label, record);
+      }
+      return this.buildSaveResult(record.Id);
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    if (!this.isSaveFailure(record)) {
-      this.recordUpsert(label, record);
-    }
-    return this.buildSaveResult(record.Id);
   }
 
   /**
@@ -645,19 +750,24 @@ public with sharing class MockEloquent implements IEloquent {
   public Database.SaveResult doUpdate(IEntry entry, Boolean allOrNone) {
     String method = 'doUpdate(IEntry entry, Boolean allOrNone)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (entry == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (entry == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
+      }
 
-    SObject record = entry.getRecord();
-    if (allOrNone == true) {
-      this.enforceAllOrNone(method, record);
+      SObject record = entry.getRecord();
+      if (allOrNone == true) {
+        this.enforceAllOrNone(method, record);
+      }
+      if (!this.isSaveFailure(record)) {
+        this.recordUpsert(label, record);
+      }
+      return this.buildSaveResult(record.Id);
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    if (!this.isSaveFailure(record)) {
-      this.recordUpsert(label, record);
-    }
-    return this.buildSaveResult(record.Id);
   }
 
   /**
@@ -666,24 +776,29 @@ public with sharing class MockEloquent implements IEloquent {
   public List<Database.SaveResult> doUpdate(List<SObject> records, Boolean allOrNone) {
     String method = 'doUpdate(List<SObject> records, Boolean allOrNone)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (records == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (records == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
+      }
 
-    if (allOrNone == true) {
+      if (allOrNone == true) {
+        for (SObject record : records) {
+          this.enforceAllOrNone(method, record);
+        }
+      }
+      List<Database.SaveResult> results = new List<Database.SaveResult>();
       for (SObject record : records) {
-        this.enforceAllOrNone(method, record);
+        if (!this.isSaveFailure(record)) {
+          this.recordUpsert(label, record);
+        }
+        results.add(this.buildSaveResult(record.Id));
       }
+      return results;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    List<Database.SaveResult> results = new List<Database.SaveResult>();
-    for (SObject record : records) {
-      if (!this.isSaveFailure(record)) {
-        this.recordUpsert(label, record);
-      }
-      results.add(this.buildSaveResult(record.Id));
-    }
-    return results;
   }
 
   /**
@@ -692,25 +807,30 @@ public with sharing class MockEloquent implements IEloquent {
   public List<Database.SaveResult> doUpdate(List<IEntry> entries, Boolean allOrNone) {
     String method = 'doUpdate(List<IEntry> entries, Boolean allOrNone)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (entries == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (entries == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
+      }
 
-    if (allOrNone == true) {
+      if (allOrNone == true) {
+        for (IEntry entry : entries) {
+          this.enforceAllOrNone(method, entry.getRecord());
+        }
+      }
+      List<Database.SaveResult> results = new List<Database.SaveResult>();
       for (IEntry entry : entries) {
-        this.enforceAllOrNone(method, entry.getRecord());
+        SObject record = entry.getRecord();
+        if (!this.isSaveFailure(record)) {
+          this.recordUpsert(label, record);
+        }
+        results.add(this.buildSaveResult(record.Id));
       }
+      return results;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    List<Database.SaveResult> results = new List<Database.SaveResult>();
-    for (IEntry entry : entries) {
-      SObject record = entry.getRecord();
-      if (!this.isSaveFailure(record)) {
-        this.recordUpsert(label, record);
-      }
-      results.add(this.buildSaveResult(record.Id));
-    }
-    return results;
   }
 
   private Boolean isSaveFailure(SObject record) {
@@ -762,16 +882,21 @@ public with sharing class MockEloquent implements IEloquent {
   public SObject doUpsert(SObject record) {
     String method = 'doUpsert(SObject record)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (record == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (record == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
+      }
 
-    if (record.Id == null) {
-      record.Id = this.generateId(record);
+      if (record.Id == null) {
+        record.Id = this.generateId(record);
+      }
+      this.recordUpsert(label, record);
+      return record;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    this.recordUpsert(label, record);
-    return record;
   }
 
   /**
@@ -780,17 +905,22 @@ public with sharing class MockEloquent implements IEloquent {
   public IEntry doUpsert(IEntry entry) {
     String method = 'doUpsert(IEntry entry)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (entry == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (entry == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
+      }
 
-    SObject record = entry.getRecord();
-    if (record.Id == null) {
-      entry.put('Id', this.generateId(record));
+      SObject record = entry.getRecord();
+      if (record.Id == null) {
+        entry.put('Id', this.generateId(record));
+      }
+      this.recordUpsert(label, record);
+      return entry;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    this.recordUpsert(label, record);
-    return entry;
   }
 
   /**
@@ -799,30 +929,35 @@ public with sharing class MockEloquent implements IEloquent {
   public List<SObject> doUpsert(List<SObject> records) {
     String method = 'doUpsert(List<SObject> records)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (records == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (records == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
+      }
 
-    for (SObject record : records) {
-      if (record == null) {
-        String error = 'Null record found in records list';
-        String reason = 'The list of records to upsert contains a null value, which is not allowed';
-        String action = 'Ensure that the list of records passed to doUpsert does not contain any null values';
-        ApexEloquentException.at(CLASS_NAME)
-          .method(method)
-          .error(error)
-          .reason(reason)
-          .action(action)
-          .param('records', records)
-          .fire();
+      for (SObject record : records) {
+        if (record == null) {
+          String error = 'Null record found in records list';
+          String reason = 'The list of records to upsert contains a null value, which is not allowed';
+          String action = 'Ensure that the list of records passed to doUpsert does not contain any null values';
+          ApexEloquentException.at(CLASS_NAME)
+            .method(method)
+            .error(error)
+            .reason(reason)
+            .action(action)
+            .param('records', records)
+            .fire();
+        }
+        if (record.Id == null) {
+          record.Id = this.generateId(record);
+        }
+        this.recordUpsert(label, record);
       }
-      if (record.Id == null) {
-        record.Id = this.generateId(record);
-      }
-      this.recordUpsert(label, record);
+      return records;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return records;
   }
 
   /**
@@ -831,31 +966,36 @@ public with sharing class MockEloquent implements IEloquent {
   public List<IEntry> doUpsert(List<IEntry> entries) {
     String method = 'doUpsert(List<IEntry> entries)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (entries == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (entries == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
+      }
 
-    for (IEntry entry : entries) {
-      if (entry == null || entry.getRecord() == null) {
-        String error = 'Null entry found in entries list';
-        String reason = 'The list of entries to upsert contains a null value, which is not allowed';
-        String action = 'Ensure that the list of entries passed to doUpsert does not contain any null values';
-        ApexEloquentException.at(CLASS_NAME)
-          .method(method)
-          .error(error)
-          .reason(reason)
-          .action(action)
-          .param('entries', entries)
-          .fire();
+      for (IEntry entry : entries) {
+        if (entry == null || entry.getRecord() == null) {
+          String error = 'Null entry found in entries list';
+          String reason = 'The list of entries to upsert contains a null value, which is not allowed';
+          String action = 'Ensure that the list of entries passed to doUpsert does not contain any null values';
+          ApexEloquentException.at(CLASS_NAME)
+            .method(method)
+            .error(error)
+            .reason(reason)
+            .action(action)
+            .param('entries', entries)
+            .fire();
+        }
+        SObject record = entry.getRecord();
+        if (record.Id == null) {
+          entry.put('Id', this.generateId(record));
+        }
+        this.recordUpsert(label, record);
       }
-      SObject record = entry.getRecord();
-      if (record.Id == null) {
-        entry.put('Id', this.generateId(record));
-      }
-      this.recordUpsert(label, record);
+      return entries;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return entries;
   }
 
   /**
@@ -868,23 +1008,28 @@ public with sharing class MockEloquent implements IEloquent {
   ) {
     String method = 'doUpsertByExternalId(SObject record, Schema.SObjectField externalIdField, Boolean allOrNone)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (record == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (record == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
+      }
 
-    if (allOrNone == true) {
-      this.enforceAllOrNone(method, record);
+      if (allOrNone == true) {
+        this.enforceAllOrNone(method, record);
+      }
+      if (this.isSaveFailure(record)) {
+        return this.buildFailedUpsertResult(record.Id);
+      }
+      Boolean isCreated = record.Id == null;
+      if (isCreated) {
+        record.Id = this.generateId(record);
+      }
+      this.recordUpsert(label, record);
+      return buildSuccessUpsertResult(record.Id, isCreated);
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    if (this.isSaveFailure(record)) {
-      return this.buildFailedUpsertResult(record.Id);
-    }
-    Boolean isCreated = record.Id == null;
-    if (isCreated) {
-      record.Id = this.generateId(record);
-    }
-    this.recordUpsert(label, record);
-    return buildSuccessUpsertResult(record.Id, isCreated);
   }
 
   /**
@@ -897,24 +1042,29 @@ public with sharing class MockEloquent implements IEloquent {
   ) {
     String method = 'doUpsertByExternalId(IEntry entry, Schema.SObjectField externalIdField, Boolean allOrNone)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (entry == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (entry == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
+      }
 
-    SObject record = entry.getRecord();
-    if (allOrNone == true) {
-      this.enforceAllOrNone(method, record);
+      SObject record = entry.getRecord();
+      if (allOrNone == true) {
+        this.enforceAllOrNone(method, record);
+      }
+      if (this.isSaveFailure(record)) {
+        return this.buildFailedUpsertResult(record.Id);
+      }
+      Boolean isCreated = record.Id == null;
+      if (isCreated) {
+        entry.put('Id', this.generateId(record));
+      }
+      this.recordUpsert(label, record);
+      return buildSuccessUpsertResult(record.Id, isCreated);
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    if (this.isSaveFailure(record)) {
-      return this.buildFailedUpsertResult(record.Id);
-    }
-    Boolean isCreated = record.Id == null;
-    if (isCreated) {
-      entry.put('Id', this.generateId(record));
-    }
-    this.recordUpsert(label, record);
-    return buildSuccessUpsertResult(record.Id, isCreated);
   }
 
   /**
@@ -927,40 +1077,45 @@ public with sharing class MockEloquent implements IEloquent {
   ) {
     String method = 'doUpsertByExternalId(List<SObject> records, Schema.SObjectField externalIdField, Boolean allOrNone)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (records == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (records == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
+      }
 
-    List<Database.UpsertResult> results = new List<Database.UpsertResult>();
-    for (SObject record : records) {
-      if (record == null) {
-        String error = 'Null record found in records list';
-        String reason = 'The list of records to upsert contains a null value, which is not allowed';
-        String action = 'Ensure that the list of records passed to doUpsertByExternalId does not contain any null values';
-        ApexEloquentException.at(CLASS_NAME)
-          .method(method)
-          .error(error)
-          .reason(reason)
-          .action(action)
-          .param('records', records)
-          .fire();
+      List<Database.UpsertResult> results = new List<Database.UpsertResult>();
+      for (SObject record : records) {
+        if (record == null) {
+          String error = 'Null record found in records list';
+          String reason = 'The list of records to upsert contains a null value, which is not allowed';
+          String action = 'Ensure that the list of records passed to doUpsertByExternalId does not contain any null values';
+          ApexEloquentException.at(CLASS_NAME)
+            .method(method)
+            .error(error)
+            .reason(reason)
+            .action(action)
+            .param('records', records)
+            .fire();
+        }
+        if (allOrNone == true) {
+          this.enforceAllOrNone(method, record);
+        }
+        if (this.isSaveFailure(record)) {
+          results.add(this.buildFailedUpsertResult(record.Id));
+          continue;
+        }
+        Boolean isCreated = record.Id == null;
+        if (isCreated) {
+          record.Id = this.generateId(record);
+        }
+        this.recordUpsert(label, record);
+        results.add(buildSuccessUpsertResult(record.Id, isCreated));
       }
-      if (allOrNone == true) {
-        this.enforceAllOrNone(method, record);
-      }
-      if (this.isSaveFailure(record)) {
-        results.add(this.buildFailedUpsertResult(record.Id));
-        continue;
-      }
-      Boolean isCreated = record.Id == null;
-      if (isCreated) {
-        record.Id = this.generateId(record);
-      }
-      this.recordUpsert(label, record);
-      results.add(buildSuccessUpsertResult(record.Id, isCreated));
+      return results;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return results;
   }
 
   /**
@@ -973,41 +1128,46 @@ public with sharing class MockEloquent implements IEloquent {
   ) {
     String method = 'doUpsertByExternalId(List<IEntry> entries, Schema.SObjectField externalIdField, Boolean allOrNone)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (entries == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (entries == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
+      }
 
-    List<Database.UpsertResult> results = new List<Database.UpsertResult>();
-    for (IEntry entry : entries) {
-      if (entry == null || entry.getRecord() == null) {
-        String error = 'Null entry found in entries list';
-        String reason = 'The list of entries to upsert contains a null value, which is not allowed';
-        String action = 'Ensure that the list of entries passed to doUpsertByExternalId does not contain any null values';
-        ApexEloquentException.at(CLASS_NAME)
-          .method(method)
-          .error(error)
-          .reason(reason)
-          .action(action)
-          .param('entries', entries)
-          .fire();
+      List<Database.UpsertResult> results = new List<Database.UpsertResult>();
+      for (IEntry entry : entries) {
+        if (entry == null || entry.getRecord() == null) {
+          String error = 'Null entry found in entries list';
+          String reason = 'The list of entries to upsert contains a null value, which is not allowed';
+          String action = 'Ensure that the list of entries passed to doUpsertByExternalId does not contain any null values';
+          ApexEloquentException.at(CLASS_NAME)
+            .method(method)
+            .error(error)
+            .reason(reason)
+            .action(action)
+            .param('entries', entries)
+            .fire();
+        }
+        SObject record = entry.getRecord();
+        if (allOrNone == true) {
+          this.enforceAllOrNone(method, record);
+        }
+        if (this.isSaveFailure(record)) {
+          results.add(this.buildFailedUpsertResult(record.Id));
+          continue;
+        }
+        Boolean isCreated = record.Id == null;
+        if (isCreated) {
+          entry.put('Id', this.generateId(record));
+        }
+        this.recordUpsert(label, record);
+        results.add(buildSuccessUpsertResult(record.Id, isCreated));
       }
-      SObject record = entry.getRecord();
-      if (allOrNone == true) {
-        this.enforceAllOrNone(method, record);
-      }
-      if (this.isSaveFailure(record)) {
-        results.add(this.buildFailedUpsertResult(record.Id));
-        continue;
-      }
-      Boolean isCreated = record.Id == null;
-      if (isCreated) {
-        entry.put('Id', this.generateId(record));
-      }
-      this.recordUpsert(label, record);
-      results.add(buildSuccessUpsertResult(record.Id, isCreated));
+      return results;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
     }
-    return results;
   }
 
   private Database.UpsertResult buildFailedUpsertResult(Id recordId) {
@@ -1037,13 +1197,18 @@ public with sharing class MockEloquent implements IEloquent {
   public void doDelete(SObject record) {
     String method = 'doDelete(SObject record)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (record == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (record == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
+      }
 
-    this.recordDelete(label, 1);
-    return;
+      this.recordDelete(label, 1);
+      return;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -1052,13 +1217,18 @@ public with sharing class MockEloquent implements IEloquent {
   public void doDelete(IEntry entry) {
     String method = 'doDelete(IEntry entry)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (entry == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (entry == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
+      }
 
-    this.recordDelete(label, 1);
-    return;
+      this.recordDelete(label, 1);
+      return;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -1067,13 +1237,18 @@ public with sharing class MockEloquent implements IEloquent {
   public void doDelete(List<SObject> records) {
     String method = 'doDelete(List<SObject> records)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (records == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (records == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
+      }
 
-    this.recordDelete(label, records.size());
-    return;
+      this.recordDelete(label, records.size());
+      return;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   /**
@@ -1082,13 +1257,18 @@ public with sharing class MockEloquent implements IEloquent {
   public void doDelete(List<IEntry> entries) {
     String method = 'doDelete(List<IEntry> entries)';
     String label = this.consumeLabel();
-    this.handleErrorQueue(method, label);
-    if (entries == null) {
-      ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
-    }
+    try {
+      this.handleErrorQueue(method, label);
+      if (entries == null) {
+        ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
+      }
 
-    this.recordDelete(label, entries.size());
-    return;
+      this.recordDelete(label, entries.size());
+      return;
+    } catch (Exception e) {
+      this.releaseLabel(label);
+      throw e;
+    }
   }
 
   public MockEloquent failOnGet() {
@@ -1217,23 +1397,71 @@ public with sharing class MockEloquent implements IEloquent {
 
   private void handleErrorQueue(String methodWithArguments, String label) {
     String method = methodWithArguments.split('\\(')[0];
-    if (!this.errorQueueMap.containsKey(method) || this.errorQueueMap.get(method).isEmpty()) {
+    List<ErrorConfig> queue = this.errorQueueMap.get(method);
+    if (queue == null || queue.isEmpty()) {
       return;
     }
-    ErrorConfig head = this.errorQueueMap.get(method).get(0);
-    if (head.label != null && head.label != label) {
-      // label-scoped config but the current call's label does not match — skip
-      // without dequeue so a later matching call can consume it.
-      return;
+
+    // scan in insertion order — within one label this is naturally FIFO
+    Integer hitIndex = -1;
+    for (Integer i = 0; i < queue.size(); i++) {
+      if (this.effectiveLabel(queue[i]) == label) {
+        hitIndex = i;
+        break;
+      }
     }
-    ErrorConfig config = this.errorQueueMap.get(method).remove(0);
+
+    if (hitIndex == -1) {
+      this.assertNoUnreachableDefaultConfig(method, label, queue);
+      return; // consume nothing — a later matching call may still hit
+    }
+
+    ErrorConfig config = queue.remove(hitIndex);
     if (config.isRepeat) {
-      this.errorQueueMap.get(method).add(config);
+      queue.add(config);
     }
     if (config.ex instanceof ApexEloquentException) {
       ((ApexEloquentException) config.ex).method(methodWithArguments).fire();
     }
     throw config.ex;
+  }
+
+  /**
+   * A failOnXxx registered without whenLabel(...) targets the 'default' label —
+   * the label every lenient (label-free) operation runs under.
+   */
+  private String effectiveLabel(ErrorConfig config) {
+    return config.label == null ? DEFAULT_LABEL : config.label;
+  }
+
+  /**
+   * In strict mode no operation ever runs under 'default' (label() is mandatory),
+   * so a failOnXxx registered without whenLabel(...) can never fire. Silently
+   * ignoring it yields "the exception never came → Assert.fail" with no clue —
+   * diagnose the dead config instead.
+   */
+  private void assertNoUnreachableDefaultConfig(String method, String label, List<ErrorConfig> queue) {
+    if (!this.strictMode) {
+      return; // lenient: every call runs under 'default', the config is reachable
+    }
+    for (ErrorConfig config : queue) {
+      if (config.label != null) {
+        continue;
+      }
+      String reason =
+        'A failOnXxx for \'' +
+        method +
+        '\' was registered without whenLabel(...), so it targets the \'' +
+        DEFAULT_LABEL +
+        '\' label. This MockEloquent is in strict mode (labels are in use), where no operation ever runs under \'' +
+        DEFAULT_LABEL +
+        '\' — the failure can never fire.';
+      String action = 'Scope it to the call site you want to fail: .whenLabel(\'' + label + '\')';
+      ApexEloquentException.invalidOperation(CLASS_NAME, 'whenLabel(String label) [unreachable config]', reason)
+        .action(action)
+        .param('label', label)
+        .fire();
+    }
   }
 
   /**

--- a/Eloquents/tests/EloquentTest.cls
+++ b/Eloquents/tests/EloquentTest.cls
@@ -1220,13 +1220,11 @@ public with sharing class EloquentTest {
   }
 
   @isTest
-  static void testLabel_AfterLabelCall_ReusingSameLabelThrows() {
+  static void testLabel_AfterSuccessfulOp_ReusingSameLabelThrows() {
+    // consume-once guards one SUCCESSFUL operation per label, so the first op
+    // must succeed for the reuse to be a violation (a failed op releases its label)
     Eloquent eloquent = new Eloquent();
-    try {
-      eloquent.label('dup').doUpdate(new Opportunity(Id = '006000000000000', Name = 'X'));
-    } catch (ApexEloquentException e) {
-      // expected — invalid Id. 'dup' is consumed.
-    }
+    eloquent.label('dup').doInsert(buildGroup('consumeOnce'));
     try {
       eloquent.label('dup').doUpdate(new Opportunity(Id = '006000000000001', Name = 'Y'));
       Assert.fail('Expected consume-once exception when reusing label.');
@@ -1236,6 +1234,24 @@ public with sharing class EloquentTest {
         'Expected consume-once message, got: ' + e.getMessage()
       );
       Assert.isTrue(e.getMessage().contains('dup'), 'Should mention the label name.');
+    }
+  }
+
+  @isTest
+  static void testLabel_WhenOpFails_ThenLabelReleasedForRetry() {
+    // a failed op releases its label, so a retry loop can reuse the same
+    // label — the 2nd attempt must fail with the DML error, not consume-once
+    Eloquent eloquent = new Eloquent();
+    for (Integer attempt = 1; attempt <= 2; attempt++) {
+      try {
+        eloquent.label('upd').doUpdate(new Opportunity(Id = '006000000000000', Name = 'X'));
+        Assert.fail('Expected DML failure (invalid Id) on attempt ' + attempt + '.');
+      } catch (ApexEloquentException e) {
+        Assert.isTrue(
+          e.getMessage().contains('Failed to update operation'),
+          'Attempt ' + attempt + ' must fail with the DML error, not consume-once. Got: ' + e.getMessage()
+        );
+      }
     }
   }
 

--- a/Eloquents/tests/MockEloquentTest.cls
+++ b/Eloquents/tests/MockEloquentTest.cls
@@ -2789,14 +2789,206 @@ public with sharing class MockEloquentTest {
   }
 
   @isTest
-  static void testFailOnXxx_WithoutWhenLabel_ThenFiresRegardlessOfLabel() {
+  static void testFailOnXxx_WithoutWhenLabel_WhenLenientCall_ThenFires() {
+    MockEloquent mock = (new MockEloquent()).failOnGet();
+    Scribe scribe = Scribe.of(Account.class).field('Name');
+    try {
+      mock.get(scribe);
+      Assert.fail('Label-free failOnGet must fire for a label-free (default) call.');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('MockEloquent was configured to throw'));
+    }
+  }
+
+  @isTest
+  static void testFailOnXxx_WithoutWhenLabel_WhenStrictCall_ThenThrowsUnreachableConfig() {
+    // strict mode never runs under 'default', so a label-free failOnGet can
+    // never fire — the mock diagnoses the dead config instead of staying silent
     MockEloquent mock = (new MockEloquent()).failOnGet();
     Scribe scribe = Scribe.of(Account.class).field('Name');
     try {
       mock.label('anyLabel').get(scribe);
-      Assert.fail('Global failOnGet (no whenLabel) should fire regardless of label.');
+      Assert.fail('Expected unreachable-config diagnostic.');
     } catch (ApexEloquentException e) {
-      Assert.isTrue(e.getMessage().contains('MockEloquent was configured to throw'));
+      Assert.isTrue(e.getMessage().contains('unreachable config'), e.getMessage());
+      Assert.isTrue(e.getMessage().contains('anyLabel'), 'Diagnostic should suggest the call label.');
+    }
+  }
+
+  @isTest
+  static void testWhenLabel_WhenNullOrBlank_ThenThrowRequired() {
+    try {
+      (new MockEloquent()).failOnGet().whenLabel(null);
+      Assert.fail('Expected required-argument exception for null label.');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('The `label` argument is required'), e.getMessage());
+    }
+    try {
+      (new MockEloquent()).failOnGet().whenLabel(' ');
+      Assert.fail('Expected required-argument exception for blank label.');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('The `label` argument is required'), e.getMessage());
+    }
+  }
+
+  @isTest
+  static void testWhenLabel_WhenDefaultLabel_ThenThrowInvalidOperation() {
+    // registering without whenLabel(...) already targets 'default' — naming it is redundant
+    try {
+      (new MockEloquent()).failOnGet().whenLabel('default');
+      Assert.fail('Expected invalid-operation exception for the reserved default label.');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('redundant'), e.getMessage());
+    }
+  }
+
+  @isTest
+  static void testFailOn_WhenTwoLabeledConfigsOnSameMethod_ThenEachFiresForItsLabel() {
+    // no head-of-line blocking: even with the 'X' config at the queue head,
+    // a 'Y' call must reach the 'Y' config
+    MockEloquent mock = (new MockEloquent())
+      .failOnGet(new QueryException('for X'))
+      .whenLabel('X')
+      .failOnGet(new QueryException('for Y'))
+      .whenLabel('Y');
+    Scribe scribe = Scribe.of(Account.class).field('Name');
+
+    try {
+      mock.label('Y').get(scribe);
+      Assert.fail('Y-scoped failure must fire.');
+    } catch (QueryException e) {
+      Assert.areEqual('for Y', e.getMessage());
+    }
+
+    try {
+      mock.label('X').get(scribe);
+      Assert.fail('X-scoped failure must fire.');
+    } catch (QueryException e) {
+      Assert.areEqual('for X', e.getMessage());
+    }
+  }
+
+  @isTest
+  static void testFailOn_WhenLabelMismatch_ThenConfigSurvivesForLaterMatch() {
+    MockEloquent mock = (new MockEloquent())
+      .attach('quote', new List<IEntry>())
+      .failOnGet(new QueryException('boom'))
+      .whenLabel('opp');
+    Scribe scribe = Scribe.of(Account.class).field('Name');
+
+    // mismatch — must not fire, must not be consumed
+    Assert.areEqual(0, mock.label('quote').get(scribe).size());
+
+    try {
+      mock.label('opp').get(scribe);
+      Assert.fail('The surviving config must fire for its label.');
+    } catch (QueryException e) {
+      Assert.areEqual('boom', e.getMessage());
+    }
+  }
+
+  // ===========================================================================
+  // Error-injection semantics (issues #62 / #64): failures form a FIFO queue
+  // per label ('default' = label-free calls). A failed operation releases its
+  // label — consume-once guards one SUCCESSFUL operation per label — so the
+  // labeled scenarios below retry under the same label.
+  // ===========================================================================
+
+  @isTest
+  static void testScenario_TwoDefaultConfigs_ThenFifoThenSuccess() {
+    // 1回目A、2回目B、3回目成功
+    MockEloquent mock = (new MockEloquent())
+      .failOnGet(new QueryException('A'))
+      .failOnGet(new QueryException('B'));
+    Scribe scribe = Scribe.of(Account.class).field('Name');
+
+    try {
+      mock.get(scribe);
+      Assert.fail('1st call must fail with A.');
+    } catch (QueryException e) {
+      Assert.areEqual('A', e.getMessage());
+    }
+    try {
+      mock.get(scribe);
+      Assert.fail('2nd call must fail with B.');
+    } catch (QueryException e) {
+      Assert.areEqual('B', e.getMessage());
+    }
+    Assert.areEqual(0, mock.get(scribe).size(), '3rd call succeeds.');
+  }
+
+  @isTest
+  static void testScenario_DefaultRepeat_ThenFailsEveryTime() {
+    // 毎回失敗
+    MockEloquent mock = (new MockEloquent()).failOnGet(new QueryException('boom')).repeat();
+    Scribe scribe = Scribe.of(Account.class).field('Name');
+    for (Integer attempt = 1; attempt <= 3; attempt++) {
+      try {
+        mock.get(scribe);
+        Assert.fail('Attempt ' + attempt + ' must fail.');
+      } catch (QueryException e) {
+        Assert.areEqual('boom', e.getMessage());
+      }
+    }
+  }
+
+  @isTest
+  static void testScenario_LabeledConfig_ThenFailsOnceThenRetrySucceeds() {
+    // opp は1回失敗 → リトライされれば2回目は成功
+    MockEloquent mock = (new MockEloquent())
+      .attach('opp', new List<IEntry>{ MockEntry.of(Account.class).autoId(1).set('Name', 'X') })
+      .failOnGet(new QueryException('boom'))
+      .whenLabel('opp');
+    Scribe scribe = Scribe.of(Account.class).field('Name');
+
+    try {
+      mock.label('opp').get(scribe);
+      Assert.fail('1st attempt must fail.');
+    } catch (QueryException e) {
+      Assert.areEqual('boom', e.getMessage());
+    }
+    // the failure released 'opp' — the retry reaches the attached data
+    Assert.areEqual('X', mock.label('opp').get(scribe)[0].get('Name'));
+  }
+
+  @isTest
+  static void testScenario_TwoLabeledConfigsSameLabel_ThenFifoAcrossRetries() {
+    // opp は1回目A、2回目B、3回目成功
+    MockEloquent mock = (new MockEloquent())
+      .attach('opp', new List<IEntry>())
+      .failOnGet(new QueryException('A'))
+      .whenLabel('opp')
+      .failOnGet(new QueryException('B'))
+      .whenLabel('opp');
+    Scribe scribe = Scribe.of(Account.class).field('Name');
+
+    try {
+      mock.label('opp').get(scribe);
+      Assert.fail('1st attempt must fail with A.');
+    } catch (QueryException e) {
+      Assert.areEqual('A', e.getMessage());
+    }
+    try {
+      mock.label('opp').get(scribe);
+      Assert.fail('2nd attempt must fail with B.');
+    } catch (QueryException e) {
+      Assert.areEqual('B', e.getMessage());
+    }
+    Assert.areEqual(0, mock.label('opp').get(scribe).size(), '3rd attempt succeeds.');
+  }
+
+  @isTest
+  static void testScenario_LabeledRepeat_ThenFailsEveryAttempt() {
+    // opp でエラーが繰り返し起こる — the chain does what it reads
+    MockEloquent mock = (new MockEloquent()).failOnGet(new QueryException('boom')).whenLabel('opp').repeat();
+    Scribe scribe = Scribe.of(Account.class).field('Name');
+    for (Integer attempt = 1; attempt <= 3; attempt++) {
+      try {
+        mock.label('opp').get(scribe);
+        Assert.fail('Attempt ' + attempt + ' must fail.');
+      } catch (QueryException e) {
+        Assert.areEqual('boom', e.getMessage());
+      }
     }
   }
 
@@ -2938,22 +3130,22 @@ public with sharing class MockEloquentTest {
   }
 
   @isTest
-  static void testStrict_OpThrowsViaFailOn_LabelStillConsumed() {
-    // Even when the op throws via failOnGet, the label is consumed. Reusing
-    // it should still hit consume-once on the second attempt.
-    MockEloquent mock = (new MockEloquent()).failOnGet();
+  static void testStrict_OpThrowsViaFailOn_LabelReleasedForRetry() {
+    // A failed op does not fulfill the label's intent: the label is released
+    // (consume-once = one SUCCESS per label), so a retry under the same label
+    // reaches the next outcome — here, the attached data.
+    MockEloquent mock = (new MockEloquent())
+      .attach('a', new List<IEntry>())
+      .failOnGet(new QueryException('boom'))
+      .whenLabel('a');
     Scribe scribe = Scribe.of(Account.class).field('Name');
     try {
-      mock.label('a').get(scribe); // throws via failOnGet — 'a' still consumed
-    } catch (ApexEloquentException e) {
-      // expected
+      mock.label('a').get(scribe);
+      Assert.fail('1st attempt must fail via failOnGet.');
+    } catch (QueryException e) {
+      Assert.areEqual('boom', e.getMessage());
     }
-    try {
-      mock.label('a').get(scribe); // 'a' already consumed
-      Assert.fail('Expected consume-once exception on label reuse.');
-    } catch (ApexEloquentException e) {
-      Assert.isTrue(e.getMessage().contains('already been consumed'));
-    }
+    Assert.areEqual(0, mock.label('a').get(scribe).size(), 'Retry under the released label succeeds.');
   }
 
   @isTest


### PR DESCRIPTION
Closes #62
Closes #64

## The model (discussed in #64)

Failures form a **FIFO queue per label** ('default' = label-free calls), and **consume-once now guards one *successful* operation per label** — a failed operation releases its label so the same label can be retried. With that, labeled error injection executes exactly the way it reads:

```apex
mock.failOnGet(exA).failOnGet(exB);              // シナリオ: 1回目A、2回目B、3回目成功
mock.failOnGet(ex).repeat();                     // シナリオ: 毎回失敗
mock.failOnGet(ex).whenLabel('opp');             // opp は1回失敗 → リトライされれば2回目は成功
mock.failOnGet(exA).whenLabel('opp')
    .failOnGet(exB).whenLabel('opp');            // opp は1回目A、2回目B、3回目成功
mock.failOnGet(ex).whenLabel('opp').repeat();    // opp でエラーが繰り返し起こる (読んだ通り)
```

## Fixes

- **#62 head-of-line blocking**: `handleErrorQueue` scanned only the queue head, so two configs for different labels on one method starved the second one forever. It now scans for the current label (insertion order = per-label FIFO); a mismatched call consumes nothing.
- **Strict unreachable-config diagnostic**: in strict mode no operation runs under 'default', so a label-free `failOnXxx` can never fire — it is now diagnosed with the call label to paste into `.whenLabel(...)`, instead of silently producing "the exception never came".
- **`whenLabel` argument guards**: `null`/blank → required; `'default'` → invalid (label-free registration already targets it).
- **#64 label release on failure** (both `Eloquent` and `MockEloquent`, kept in sync so the mock is never looser than production): every op body is wrapped to release the consumed label when the operation throws. Production retry loops under a single label now work — previously the 2nd iteration always died on consume-once, an ApexEloquentException the `catch (DmlException)` retry pattern doesn't even catch.

## Test changes

- Rewritten (old contracts): `testFailOnXxx_WithoutWhenLabel_ThenFiresRegardlessOfLabel` → lenient-fires / strict-diagnoses pair; `testStrict_OpThrowsViaFailOn_LabelStillConsumed` → `...LabelReleasedForRetry`; `testLabel_AfterLabelCall_ReusingSameLabelThrows` → consume-once now proven via a *successful* Group insert.
- New: the 5-scenario spec block above as `testScenario_*` (doubles as documentation), no-head-of-line + config-survives-mismatch, whenLabel guards, unreachable-config diagnostic, and production-side `testLabel_WhenOpFails_ThenLabelReleasedForRetry`.

MockEloquentTest + EloquentTest: 281 tests, 0 failures on a Developer Edition org.

After merge: backport to `v2.2.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)