### PR TITLE
Make describeResult transient and route all reads through describe() (fixes Stateful serialization + unknown-field NPE)

### DIFF
--- a/Entries/AbstractEntry.cls
+++ b/Entries/AbstractEntry.cls
@@ -27,7 +27,10 @@ public abstract class AbstractEntry implements IEntry {
   protected final SObject record;
   protected final AggregateResult aggregateResult;
   protected final FieldStructure fieldStructure;
-  protected Schema.DescribeSObjectResult describeResult;
+  // Schema.DescribeSObjectResult is not serializable, so keep it out of serialization
+  // (Database.Stateful batch state, Queueable/Schedulable, view state).
+  // Re-derived on demand by ensureDescribeResultIfNeeded() after deserialization.
+  protected transient Schema.DescribeSObjectResult describeResult;
   @TestVisible
   protected Boolean hasAggregateResult = false;
 
@@ -44,8 +47,7 @@ public abstract class AbstractEntry implements IEntry {
     Schema.SObjectType sObjectType = this.record.getSObjectType();
     Map<String, Schema.SObjectField> fieldMap = FIELD_MAP_CACHE.get(sObjectType);
     if (fieldMap == null) {
-      this.ensureDescribeResultIfNeeded();
-      fieldMap = this.describeResult.fields.getMap();
+      fieldMap = this.describe().fields.getMap();
       FIELD_MAP_CACHE.put(sObjectType, fieldMap);
     }
     return fieldMap;
@@ -65,7 +67,7 @@ public abstract class AbstractEntry implements IEntry {
       String reason = 'The specified field does not exist in the object\'s fields';
       String action = 'Ensure the field name is correct and exists on the SObject';
       ApexEloquentException.invalidArgument(CLASS_NAME, null, reason, action, 'fieldName', fieldName)
-        .param('objectName', this.describeResult.getName())
+        .param('objectName', this.describe().getName())
         .fire();
     }
   }
@@ -154,6 +156,19 @@ public abstract class AbstractEntry implements IEntry {
   }
 
   /**
+   * Returns the describe result, deriving it first if it is not set.
+   * Always go through this instead of reading describeResult directly:
+   * the field is transient, so it is null after deserialization — and any
+   * instance other than the type's first cache-miss never had it populated.
+   *
+   * @return describe result of this record's SObject type
+   */
+  protected Schema.DescribeSObjectResult describe() {
+    this.ensureDescribeResultIfNeeded();
+    return this.describeResult;
+  }
+
+  /**
    * Ensure that describeResult is set.
    */
   protected void ensureDescribeResultIfNeeded() {
@@ -180,7 +195,7 @@ public abstract class AbstractEntry implements IEntry {
    *                               or if there are multiple relationships with the same child object name
    */
   protected String getChildrenRelationNameFromChildObjectName(String childObjectName) {
-    List<Schema.ChildRelationship> childRelationships = this.describeResult.getChildRelationships();
+    List<Schema.ChildRelationship> childRelationships = this.describe().getChildRelationships();
     Integer size = childRelationships.size();
 
     Integer low = 0;
@@ -207,7 +222,7 @@ public abstract class AbstractEntry implements IEntry {
       String reason = 'The specified child object name does not exist on Parent';
       String action = 'Use a child SObject name that has a relationship with the parent';
       ApexEloquentException.invalidArgument(CLASS_NAME, null, reason, action, 'childObjectName', childObjectName)
-        .param('parentObjectName', this.describeResult.getName())
+        .param('parentObjectName', this.describe().getName())
         .fire();
     }
 
@@ -237,7 +252,7 @@ public abstract class AbstractEntry implements IEntry {
       String reason = 'The specified child object name is ambiguous because multiple relationships exist on Parent';
       String action = 'Use getChildrenByRelationName() with the explicit relationship name instead';
       ApexEloquentException.invalidArgument(CLASS_NAME, null, reason, action, 'childObjectName', childObjectName)
-        .param('parentObjectName', this.describeResult.getName())
+        .param('parentObjectName', this.describe().getName())
         .fire();
     }
 
@@ -251,7 +266,7 @@ public abstract class AbstractEntry implements IEntry {
    * @throws ApexEloquentException if the child relation name is not exist in the parent object's children relationships
    */
   protected void validateChildRelationName(String childRelationName) {
-    List<Schema.ChildRelationship> childRelationShips = this.describeResult.getChildRelationships();
+    List<Schema.ChildRelationship> childRelationShips = this.describe().getChildRelationships();
 
     Boolean found = false;
     for (Schema.ChildRelationship childRelationShip : childRelationShips) {
@@ -264,7 +279,7 @@ public abstract class AbstractEntry implements IEntry {
       String reason = 'The specified childRelationName does not exist in the parent object\'s children relationships';
       String action = 'Pass a valid child relationship name (e.g. `Contacts` on Account)';
       ApexEloquentException.invalidArgument(CLASS_NAME, null, reason, action, 'childRelationName', childRelationName)
-        .param('parentObjectName', this.describeResult.getName())
+        .param('parentObjectName', this.describe().getName())
         .fire();
     }
   }

--- a/Entries/Entry.cls
+++ b/Entries/Entry.cls
@@ -108,13 +108,13 @@ public with sharing class Entry extends AbstractEntry {
     }
 
     this.ensureDescribeResultIfNeeded();
-    Map<String, Schema.SObjectField> fieldMap = this.describeResult.fields.getMap();
+    Map<String, Schema.SObjectField> fieldMap = this.describe().fields.getMap();
 
     Schema.SObjectField field = fieldMap.get(parentIdFieldName);
     if (field == null) {
       String reason =
         'The specified parentIdFieldName does not exist in the object\'s fields. Object name:' +
-        this.describeResult.getName();
+        this.describe().getName();
       String action = 'Ensure that the parentIdFieldName is correct and exists in the object\'s fields.';
       ApexEloquentException.invalidArgument(
           CLASS_NAME,
@@ -130,7 +130,7 @@ public with sharing class Entry extends AbstractEntry {
     Schema.DescribeFieldResult fieldDescribe = field.getDescribe();
     if (fieldDescribe.getType() != Schema.DisplayType.Reference) {
       String reason =
-        'The specified parentIdFieldName is not a reference type. Object name:' + this.describeResult.getName();
+        'The specified parentIdFieldName is not a reference type. Object name:' + this.describe().getName();
       String action = 'Ensure that the parentIdFieldName is a reference type field.';
       ApexEloquentException.invalidArgument(
           CLASS_NAME,
@@ -302,7 +302,7 @@ public with sharing class Entry extends AbstractEntry {
       String reason = 'The specified field does not exist in the object\'s fields';
       String action = 'Ensure the field name is correct and exists on the SObject';
       ApexEloquentException.invalidArgument(CLASS_NAME, null, reason, action, 'fieldName', fieldName)
-        .param('objectName', this.describeResult.getName())
+        .param('objectName', this.describe().getName())
         .fire();
     }
   }

--- a/Entries/MockEntry.cls
+++ b/Entries/MockEntry.cls
@@ -840,7 +840,7 @@ public with sharing class MockEntry extends AbstractEntry {
     if (!this.skipFieldValidation && !this.fieldStructure.hasRelation(lowerCaseFieldName)) {
       String reason =
         'The specified parentIdFieldName is not defined as a relationship in Scribe. SObject: ' +
-        this.describeResult.getName();
+        this.describe().getName();
       String action =
         'Ensure that the parentIdFieldName \'' +
         parentIdFieldName +
@@ -1280,10 +1280,10 @@ public with sharing class MockEntry extends AbstractEntry {
   private void validateChildRelationInFieldStructure(String relation, String errorTemplate) {
     if (!this.skipFieldValidation && !this.fieldStructure.hasRelation(relation.toLowerCase())) {
       this.ensureDescribeResultIfNeeded();
-      String reason = String.format(errorTemplate, new List<String>{ relation, this.describeResult.getName() });
+      String reason = String.format(errorTemplate, new List<String>{ relation, this.describe().getName() });
       String action = 'Add the relation to the Scribe definition (.withChildren(...)) or call .withoutFieldValidation() when intentional';
       ApexEloquentException.invalidArgument(CLASS_NAME, null, reason, action, 'relation', relation)
-        .param('parentObjectName', this.describeResult.getName())
+        .param('parentObjectName', this.describe().getName())
         .fire();
     }
   }
@@ -1303,7 +1303,7 @@ public with sharing class MockEntry extends AbstractEntry {
       entries = new List<IEntry>{ (IEntry) childObjects };
     } else {
       this.ensureDescribeResultIfNeeded();
-      String reason = String.format(errorTemplate, new List<String>{ this.describeResult.getName() });
+      String reason = String.format(errorTemplate, new List<String>{ this.describe().getName() });
       ApexEloquentException.invalidOperation(CLASS_NAME, null, reason).fire();
     }
 

--- a/Entries/tests/EntryTest.cls
+++ b/Entries/tests/EntryTest.cls
@@ -528,4 +528,65 @@ public with sharing class EntryTest {
     }
   }
 
+  // ===============================================================================
+  // describeResult: transient serialization safety (issue #68) and the warm-cache
+  // NPE in the unknown-field diagnostic (issue #69).
+  // The Database.Stateful SerializationException itself cannot be reproduced in
+  // test context (synchronous executeBatch skips serialization — measured), so
+  // these tests cover the post-deserialization state (describeResult = null) and
+  // the diagnostic path; the batch behavior is verified on a real org run (#68).
+  // ===============================================================================
+
+  @isTest
+  static void testGet_WhenSecondEntryGivenUnknownField_ThenDiagnosisNotNpe() {
+    // issue #69: the field map comes from the warm per-type cache, so the second
+    // entry never populates describeResult — the unknown-field diagnostic must
+    // ensure it instead of dereferencing null
+    new Entry(new Account(Name = 'first')).get('Name'); // warms FIELD_MAP_CACHE(Account)
+    Entry second = new Entry(new Account(Name = 'second'));
+
+    try {
+      second.get('NoSuchField__c');
+      Assert.fail('Expected ApexEloquentException for the unknown field');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('NoSuchField__c'), e.getMessage());
+      Assert.isTrue(e.getMessage().contains('Account'), 'Error must name the SObject: ' + e.getMessage());
+    }
+  }
+
+  @isTest
+  static void testGet_WhenDescribeResultCleared_ThenFieldErrorStillReadable() {
+    // issue #68: simulates the post-deserialization state (transient field = null)
+    // with a warm cache — the diagnostic path must re-derive the describe
+    new Entry(new Account(Name = 'warm')).get('Name'); // warm FIELD_MAP_CACHE for Account
+    Entry entry = new Entry(new Account(Name = 'x'));
+    entry.setDescribeResult(null);
+
+    try {
+      entry.get('NoSuchField__c');
+      Assert.fail('Expected ApexEloquentException for the unknown field');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('NoSuchField__c'), e.getMessage());
+      Assert.isTrue(e.getMessage().contains('Account'), 'Error must name the SObject: ' + e.getMessage());
+    }
+  }
+
+  @isTest
+  static void testGetChildren_WhenDescribeResultCleared_ThenRederivedOnDemand() {
+    // issue #68: post-deserialization state — relationship resolution must
+    // re-derive the describe on demand
+    Entry entry = new Entry(new Account(Name = 'x'));
+    entry.setDescribeResult(null);
+
+    Assert.areEqual(0, entry.getChildren('Contact').size(), 'Valid child lookup works with a cleared describe.');
+
+    entry.setDescribeResult(null);
+    try {
+      entry.getChildren('NoSuchChild__c');
+      Assert.fail('Expected ApexEloquentException for the unknown child object');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('Account'), 'Error must name the parent SObject: ' + e.getMessage());
+    }
+  }
+
 }


### PR DESCRIPTION
Closes #68
Closes #69

## What

- **#68**: `AbstractEntry.describeResult` (`Schema.DescribeSObjectResult`) is now `transient` — it is not serializable, so `IEntry` state carried on a `Database.Stateful` batch exploded between chunks whenever the field had been populated. Population happens only on the type's **first cache-miss instance**, so the same code passed or failed depending on cache warm-up.
- **#69**: the unknown-field diagnostic dereferenced `describeResult` without ensuring it, turning "the field does not exist on Account" into a bare `NullPointerException` for every instance except the type's first — a today-bug independent of #68.

## Why an accessor instead of per-site ensure

The handoff investigation initially proposed per-site fixes after measuring "only one live NPE site". Writing the red tests disproved that: the stack trace landed in **`Entry.validateFieldName`** — a second, duplicated copy of the validation — and MockEntry carries 4 more unaudited direct reads. With the one-site theory dead, all **14 direct reads across AbstractEntry / Entry / MockEntry** now route through a `describe()` accessor that always re-derives on demand, making the bug class structurally unrepresentable. Behavior is unchanged (ensure is idempotent).

## Tests

- `testGet_WhenSecondEntryGivenUnknownField_ThenDiagnosisNotNpe` — #69's natural repro (**red before this fix**: NPE)
- `testGet_WhenDescribeResultCleared_ThenFieldErrorStillReadable` — post-deserialization state via `setDescribeResult(null)` (**red before this fix**)
- `testGetChildren_WhenDescribeResultCleared_ThenRederivedOnDemand` — locks the relationship path (already safe; callers ensure)

⚠️ The Stateful `SerializationException` itself **cannot be reproduced in test context** (synchronous `executeBatch` skips serialization — measured), and `JSON.serialize` doesn't reproduce it either (measured: the JSON serializer happily serializes DescribeSObjectResult). The batch path is verified on a real org run — 5/5 chunks, restored entries fully usable (#68).

Full suite: **805 tests, 0 failures** on a Developer Edition org.

After merge: backport to `v2.2.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)