### PR TITLE
Defer null-value errors to build time (ignoreWhen can retract them) + ignoreWhen combination matrix

### DIFF
--- a/ConditionClauses/InvalidConditionClause.cls
+++ b/ConditionClauses/InvalidConditionClause.cls
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2025 Hiroyuki Matsuoka
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @description A placeholder condition recorded when a where...() method received a
+ * null value at chain time (issue #71).
+ *
+ * Throwing immediately in the where...() call would make the condition impossible
+ * to retract: `whereIn(f, ids).ignoreWhen(ids == null)` never reaches ignoreWhen().
+ * Instead the invalid condition is recorded like any other ConditionPart — if
+ * ignoreWhen() retracts it, nothing happens; if it survives to SOQL build time,
+ * build() fires the original required-argument error, carrying the originating
+ * method and field name so the offending where...() call is identifiable.
+ * @see Scribe
+ * @see IConditionClause
+ */
+public with sharing class InvalidConditionClause implements IConditionClause {
+  private static final String CLASS_NAME = 'Scribe';
+
+  private final String method;
+  private final String field;
+
+  /**
+   * @param method the Scribe method that received the null value (for the deferred error)
+   * @param field the field name the condition was for
+   */
+  public InvalidConditionClause(String method, String field) {
+    this.method = method;
+    this.field = field;
+  }
+
+  /**
+   * Fires the deferred required-argument error: the null-valued condition survived
+   * to SOQL build time without being retracted by ignoreWhen().
+   */
+  public String build() {
+    ApexEloquentException.required(CLASS_NAME, this.method, 'value', null)
+      .param('fieldName', this.field)
+      .action(
+        'Pass a non-null value, or drop the condition by chaining .ignoreWhen(...) directly after the where...() call.'
+      )
+      .fire();
+    return null; // unreachable — fire() always throws
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public IConditionClause overrideMetaData(Schema.SObjectType sObjectType, Map<String, Schema.SObjectField> fieldMap) {
+    return this;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public IConditionClause overrideField(String field) {
+    return new InvalidConditionClause(this.method, field);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public String getFieldName() {
+    return this.field;
+  }
+}

--- a/ConditionClauses/InvalidConditionClause.cls-meta.xml
+++ b/ConditionClauses/InvalidConditionClause.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/Eloquents/tests/EloquentTest.cls
+++ b/Eloquents/tests/EloquentTest.cls
@@ -1526,4 +1526,64 @@ public with sharing class EloquentTest {
       Assert.isTrue(e.getMessage().contains('The `orFail` argument is required'), e.getMessage());
     }
   }
+
+  // ===============================================================================
+  // ignoreWhen combination matrix — real-count layer (issue #72).
+  // The empty/null semantics (whereIn empty = always false, whereNotIn empty =
+  // condition ignored, retraction = no filter) are invisible to SOQL-string
+  // comparison alone, so they are asserted here against real rows on the
+  // platform-frozen Group object.
+  // ===============================================================================
+
+  private class CountCase {
+    String name;
+    Scribe scribe;
+    Integer expected;
+    CountCase(String name, Scribe scribe, Integer expected) {
+      this.name = name;
+      this.scribe = scribe;
+      this.expected = expected;
+    }
+  }
+
+  @isTest
+  static void testIgnoreWhenMatrix_RealCounts_ThenSemanticsHold() {
+    // Arrange - three real rows to count against
+    insert new List<Group>{
+      new Group(Name = 'ScribeMx A', DeveloperName = 'ScribeMx_A_' + Datetime.now().getTime()),
+      new Group(Name = 'ScribeMx B', DeveloperName = 'ScribeMx_B_' + Datetime.now().getTime()),
+      new Group(Name = 'ScribeMx C', DeveloperName = 'ScribeMx_C_' + Datetime.now().getTime())
+    };
+
+    Set<String> emptySet = new Set<String>();
+    Set<String> nullSet = null;
+
+    List<CountCase> cases = new List<CountCase>{
+      new CountCase('baseline: all rows', base(), 3),
+      new CountCase('whereIn empty = always false', base().whereIn('Name', emptySet), 0),
+      new CountCase('whereNotIn empty = condition ignored', base().whereNotIn('Name', emptySet), 3),
+      new CountCase('whereIn empty retracted = no filter', base().whereIn('Name', emptySet).ignoreWhen(true), 3),
+      new CountCase('whereIn null retracted = no filter', base().whereIn('Name', nullSet).ignoreWhen(true), 3),
+      new CountCase('whereNotIn real value excludes', base().whereNotIn('Name', new Set<String>{ 'ScribeMx A' }), 2),
+      new CountCase(
+        'fully retracted group = no filter',
+        base().whereGroup(Scribe.asGroup().whereIn('Name', nullSet).ignoreWhen(true)),
+        3
+      ),
+      new CountCase(
+        'group survivor filters for real',
+        base().whereGroup(Scribe.asGroup().whereEqual('Name', 'ScribeMx B').whereIn('Name', nullSet).ignoreWhen(true)),
+        1
+      )
+    };
+
+    // Act & Assert
+    for (CountCase c : cases) {
+      Assert.areEqual(c.expected, (new Eloquent()).get(c.scribe).size(), c.name);
+    }
+  }
+
+  private static Scribe base() {
+    return Scribe.of(Group.class).field('Id').whereLike('Name', 'ScribeMx%');
+  }
 }

--- a/Scribe.cls
+++ b/Scribe.cls
@@ -761,7 +761,7 @@ public with sharing class Scribe {
    */
   public Scribe whereEqual(String fieldName, Object value) {
     String method = 'whereEqual(String fieldName, Object value)';
-    this.validateConditionClause(method, fieldName, value, true);
+    this.validateConditionClause(method, fieldName, value);
 
     Scribe clonedScribe = this.deepClone();
     IConditionClause conditionClause;
@@ -787,7 +787,7 @@ public with sharing class Scribe {
    */
   public Scribe whereNotEqual(String fieldName, Object value) {
     String method = 'whereNotEqual(String fieldName, Object value)';
-    this.validateConditionClause(method, fieldName, value, true);
+    this.validateConditionClause(method, fieldName, value);
 
     Scribe clonedScribe = this.deepClone();
     IConditionClause conditionClause;
@@ -813,15 +813,22 @@ public with sharing class Scribe {
    */
   public Scribe whereGreaterThan(String fieldName, Object value) {
     String method = 'whereGreaterThan(String fieldName, Object value)';
-    this.validateConditionClause(method, fieldName, value, false);
+    this.validateConditionClause(method, fieldName, value);
 
     Scribe clonedScribe = this.deepClone();
-    IConditionClause conditionClause = new GreaterThanConditionClause(
-      clonedScribe.sObjectType,
-      null,
-      fieldName,
-      value
-    );
+    IConditionClause conditionClause;
+    if (value == null) {
+      // null at chain time: defer the error to build time so a following
+      // ignoreWhen() can retract the condition first (issue #71)
+      conditionClause = new InvalidConditionClause(method, fieldName);
+    } else {
+      conditionClause = new GreaterThanConditionClause(
+        clonedScribe.sObjectType,
+        null,
+        fieldName,
+        value
+      );
+    }
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
@@ -839,15 +846,22 @@ public with sharing class Scribe {
    */
   public Scribe whereGreaterThanOrEqual(String fieldName, Object value) {
     String method = 'whereGreaterThanOrEqual(String fieldName, Object value)';
-    this.validateConditionClause(method, fieldName, value, false);
+    this.validateConditionClause(method, fieldName, value);
 
     Scribe clonedScribe = this.deepClone();
-    IConditionClause conditionClause = new GreaterThanOrEqualConditionClause(
-      clonedScribe.sObjectType,
-      null,
-      fieldName,
-      value
-    );
+    IConditionClause conditionClause;
+    if (value == null) {
+      // null at chain time: defer the error to build time so a following
+      // ignoreWhen() can retract the condition first (issue #71)
+      conditionClause = new InvalidConditionClause(method, fieldName);
+    } else {
+      conditionClause = new GreaterThanOrEqualConditionClause(
+        clonedScribe.sObjectType,
+        null,
+        fieldName,
+        value
+      );
+    }
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
@@ -865,15 +879,22 @@ public with sharing class Scribe {
    */
   public Scribe whereLessThan(String fieldName, Object value) {
     String method = 'whereLessThan(String fieldName, Object value)';
-    this.validateConditionClause(method, fieldName, value, false);
+    this.validateConditionClause(method, fieldName, value);
 
     Scribe clonedScribe = this.deepClone();
-    IConditionClause conditionClause = new LessThanConditionClause(
-      clonedScribe.sObjectType,
-      null,
-      fieldName,
-      value
-    );
+    IConditionClause conditionClause;
+    if (value == null) {
+      // null at chain time: defer the error to build time so a following
+      // ignoreWhen() can retract the condition first (issue #71)
+      conditionClause = new InvalidConditionClause(method, fieldName);
+    } else {
+      conditionClause = new LessThanConditionClause(
+        clonedScribe.sObjectType,
+        null,
+        fieldName,
+        value
+      );
+    }
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
@@ -891,15 +912,22 @@ public with sharing class Scribe {
    */
   public Scribe whereLessThanOrEqual(String fieldName, Object value) {
     String method = 'whereLessThanOrEqual(String fieldName, Object value)';
-    this.validateConditionClause(method, fieldName, value, false);
+    this.validateConditionClause(method, fieldName, value);
 
     Scribe clonedScribe = this.deepClone();
-    IConditionClause conditionClause = new LessThanOrEqualConditionClause(
-      clonedScribe.sObjectType,
-      null,
-      fieldName,
-      value
-    );
+    IConditionClause conditionClause;
+    if (value == null) {
+      // null at chain time: defer the error to build time so a following
+      // ignoreWhen() can retract the condition first (issue #71)
+      conditionClause = new InvalidConditionClause(method, fieldName);
+    } else {
+      conditionClause = new LessThanOrEqualConditionClause(
+        clonedScribe.sObjectType,
+        null,
+        fieldName,
+        value
+      );
+    }
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
@@ -917,10 +945,17 @@ public with sharing class Scribe {
    */
   public Scribe whereLike(String fieldName, String value) {
     String method = 'whereLike(String fieldName, String value)';
-    this.validateConditionClause(method, fieldName, value, false);
+    this.validateConditionClause(method, fieldName, value);
 
     Scribe clonedScribe = this.deepClone();
-    IConditionClause conditionClause = new LikeConditionClause(clonedScribe.sObjectType, null, fieldName, value);
+    IConditionClause conditionClause;
+    if (value == null) {
+      // null at chain time: defer the error to build time so a following
+      // ignoreWhen() can retract the condition first (issue #71)
+      conditionClause = new InvalidConditionClause(method, fieldName);
+    } else {
+      conditionClause = new LikeConditionClause(clonedScribe.sObjectType, null, fieldName, value);
+    }
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
@@ -938,15 +973,22 @@ public with sharing class Scribe {
    */
   public Scribe whereNotLike(String fieldName, String value) {
     String method = 'whereNotLike(String fieldName, String value)';
-    this.validateConditionClause(method, fieldName, value, false);
+    this.validateConditionClause(method, fieldName, value);
 
     Scribe clonedScribe = this.deepClone();
-    IConditionClause conditionClause = new NotLikeConditionClause(
-      clonedScribe.sObjectType,
-      null,
-      fieldName,
-      value
-    );
+    IConditionClause conditionClause;
+    if (value == null) {
+      // null at chain time: defer the error to build time so a following
+      // ignoreWhen() can retract the condition first (issue #71)
+      conditionClause = new InvalidConditionClause(method, fieldName);
+    } else {
+      conditionClause = new NotLikeConditionClause(
+        clonedScribe.sObjectType,
+        null,
+        fieldName,
+        value
+      );
+    }
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
@@ -965,10 +1007,17 @@ public with sharing class Scribe {
    */
   public Scribe whereIn(String fieldName, Object values) {
     String method = 'whereIn(String fieldName, Object values)';
-    this.validateConditionClause(method, fieldName, values, false);
+    this.validateConditionClause(method, fieldName, values);
 
     Scribe clonedScribe = this.deepClone();
-    IConditionClause conditionClause = new InConditionClause(clonedScribe.sObjectType, null, fieldName, values);
+    IConditionClause conditionClause;
+    if (values == null) {
+      // null at chain time: defer the error to build time so a following
+      // ignoreWhen() can retract the condition first (issue #71)
+      conditionClause = new InvalidConditionClause(method, fieldName);
+    } else {
+      conditionClause = new InConditionClause(clonedScribe.sObjectType, null, fieldName, values);
+    }
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
@@ -986,7 +1035,7 @@ public with sharing class Scribe {
    */
   public Scribe whereIn(String fieldName, Scribe subQuery) {
     String method = 'whereIn(String fieldName, Scribe subQuery)';
-    this.validateConditionClause(method, fieldName, subQuery, false);
+    this.validateConditionClause(method, fieldName, subQuery);
 
     Scribe clonedScribe = this.deepClone();
     if (clonedScribe.isNextConditionOr) {
@@ -999,12 +1048,19 @@ public with sharing class Scribe {
       ApexEloquentException.at(CLASS_NAME).method(method).error(error).reason(reason).action(action).fire();
     }
 
-    IConditionClause conditionClause = new InSubQueryConditionClause(
-      clonedScribe.sObjectType,
-      null,
-      fieldName,
-      subQuery
-    );
+    IConditionClause conditionClause;
+    if (subQuery == null) {
+      // null at chain time: defer the error to build time so a following
+      // ignoreWhen() can retract the condition first (issue #71)
+      conditionClause = new InvalidConditionClause(method, fieldName);
+    } else {
+      conditionClause = new InSubQueryConditionClause(
+        clonedScribe.sObjectType,
+        null,
+        fieldName,
+        subQuery
+      );
+    }
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
@@ -1023,10 +1079,17 @@ public with sharing class Scribe {
    */
   public Scribe whereNotIn(String fieldName, Object values) {
     String method = 'whereNotIn(String fieldName, Object values)';
-    this.validateConditionClause(method, fieldName, values, false);
+    this.validateConditionClause(method, fieldName, values);
 
     Scribe clonedScribe = this.deepClone();
-    IConditionClause conditionClause = new NotInConditionClause(clonedScribe.sObjectType, null, fieldName, values);
+    IConditionClause conditionClause;
+    if (values == null) {
+      // null at chain time: defer the error to build time so a following
+      // ignoreWhen() can retract the condition first (issue #71)
+      conditionClause = new InvalidConditionClause(method, fieldName);
+    } else {
+      conditionClause = new NotInConditionClause(clonedScribe.sObjectType, null, fieldName, values);
+    }
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
@@ -1044,7 +1107,7 @@ public with sharing class Scribe {
    */
   public Scribe whereNotIn(String fieldName, Scribe subQuery) {
     String method = 'whereNotIn(String fieldName, Scribe subQuery)';
-    this.validateConditionClause(method, fieldName, subQuery, false);
+    this.validateConditionClause(method, fieldName, subQuery);
 
     Scribe clonedScribe = this.deepClone();
     if (clonedScribe.isNextConditionOr) {
@@ -1057,12 +1120,19 @@ public with sharing class Scribe {
       ApexEloquentException.at(CLASS_NAME).method(method).error(error).reason(reason).action(action).fire();
     }
 
-    IConditionClause conditionClause = new NotInSubQueryConditionClause(
-      clonedScribe.sObjectType,
-      null,
-      fieldName,
-      subQuery
-    );
+    IConditionClause conditionClause;
+    if (subQuery == null) {
+      // null at chain time: defer the error to build time so a following
+      // ignoreWhen() can retract the condition first (issue #71)
+      conditionClause = new InvalidConditionClause(method, fieldName);
+    } else {
+      conditionClause = new NotInSubQueryConditionClause(
+        clonedScribe.sObjectType,
+        null,
+        fieldName,
+        subQuery
+      );
+    }
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
@@ -1080,15 +1150,22 @@ public with sharing class Scribe {
    */
   public Scribe whereIncludes(String fieldName, List<String> values) {
     String method = 'whereIncludes(String fieldName, List<String> values)';
-    this.validateConditionClause(method, fieldName, values, false);
+    this.validateConditionClause(method, fieldName, values);
 
     Scribe clonedScribe = this.deepClone();
-    IConditionClause conditionClause = new IncludesConditionClause(
-      clonedScribe.sObjectType,
-      null,
-      fieldName,
-      values
-    );
+    IConditionClause conditionClause;
+    if (values == null) {
+      // null at chain time: defer the error to build time so a following
+      // ignoreWhen() can retract the condition first (issue #71)
+      conditionClause = new InvalidConditionClause(method, fieldName);
+    } else {
+      conditionClause = new IncludesConditionClause(
+        clonedScribe.sObjectType,
+        null,
+        fieldName,
+        values
+      );
+    }
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
@@ -1106,15 +1183,22 @@ public with sharing class Scribe {
    */
   public Scribe whereExcludes(String fieldName, List<String> values) {
     String method = 'whereExcludes(String fieldName, List<String> values)';
-    this.validateConditionClause(method, fieldName, values, false);
+    this.validateConditionClause(method, fieldName, values);
 
     Scribe clonedScribe = this.deepClone();
-    IConditionClause conditionClause = new ExcludeConditionClause(
-      clonedScribe.sObjectType,
-      null,
-      fieldName,
-      values
-    );
+    IConditionClause conditionClause;
+    if (values == null) {
+      // null at chain time: defer the error to build time so a following
+      // ignoreWhen() can retract the condition first (issue #71)
+      conditionClause = new InvalidConditionClause(method, fieldName);
+    } else {
+      conditionClause = new ExcludeConditionClause(
+        clonedScribe.sObjectType,
+        null,
+        fieldName,
+        values
+      );
+    }
     ConditionPart conditionPart = new ConditionPart(conditionClause, this.isNextConditionOr);
     clonedScribe.conditionParts.add(conditionPart);
     clonedScribe.isNextConditionOr = false;
@@ -1131,7 +1215,7 @@ public with sharing class Scribe {
    */
   public Scribe whereNull(String fieldName) {
     String method = 'whereNull(String fieldName)';
-    this.validateConditionClause(method, fieldName, null, true);
+    this.validateConditionClause(method, fieldName, null);
 
     Scribe clonedScribe = this.deepClone();
     IConditionClause conditionClause = new IsNullConditionClause(clonedScribe.sObjectType, null, fieldName);
@@ -1151,7 +1235,7 @@ public with sharing class Scribe {
    */
   public Scribe whereNotNull(String fieldName) {
     String method = 'whereNotNull(String fieldName)';
-    this.validateConditionClause(method, fieldName, null, true);
+    this.validateConditionClause(method, fieldName, null);
 
     Scribe clonedScribe = this.deepClone();
     IConditionClause conditionClause = new IsNotNullConditionClause(clonedScribe.sObjectType, null, fieldName);
@@ -2203,13 +2287,13 @@ public with sharing class Scribe {
    *
    * @param fieldName The field name being added to a condition.
    */
-  private void validateConditionClause(String method, String fieldName, Object value, Boolean isAllowNullValue) {
+  private void validateConditionClause(String method, String fieldName, Object value) {
     if (fieldName == null || String.isBlank(fieldName)) {
       throw ApexEloquentException.required(CLASS_NAME, method, 'fieldName', fieldName).build();
     }
-    if (!isAllowNullValue && value == null) {
-      throw ApexEloquentException.required(CLASS_NAME, method, 'value', null).build();
-    }
+    // NOTE: a null value is NOT rejected here. Methods that cannot accept null record
+    // an InvalidConditionClause instead, deferring the error to SOQL build time so
+    // ignoreWhen() can retract the condition first (issue #71).
     this.validateConditionOperator(method, fieldName, value);
   }
 

--- a/tests/ScribeTest.cls
+++ b/tests/ScribeTest.cls
@@ -766,13 +766,17 @@ public with sharing class ScribeTest {
   }
 
   @isTest
-  static void testGreaterThan_WhenValueIsNull_ThenThrowException() {
+  static void testGreaterThan_WhenValueIsNull_ThenThrowAtBuildTime() {
     // Arrange
     Object value = null;
 
     // Arrange & Act & Assert
+    Scribe scribe = Scribe.of(Opportunity.class).field('Id').whereGreaterThan('TotalOpportunityQuantity', value);
+
+    // null no longer throws at chain time — the error is deferred to build time,
+    // so ignoreWhen() gets a chance to retract the condition first (issue #71)
     try {
-      Scribe scribe = Scribe.of(Opportunity.class).field('Id').whereGreaterThan('TotalOpportunityQuantity', value);
+      scribe.toSoql();
       Assert.fail('Expected ApexEloquentException to be thrown');
     } catch (ApexEloquentException e) {
       String error = e.getMessage();
@@ -812,15 +816,19 @@ public with sharing class ScribeTest {
   }
 
   @isTest
-  static void testGreaterThanOrEqual_WhenValueIsNull_ThenThrowException() {
+  static void testGreaterThanOrEqual_WhenValueIsNull_ThenThrowAtBuildTime() {
     // Arrange
     Object value = null;
 
     // Act & Assert
-    try {
-      Scribe scribe = Scribe.of(Opportunity.class)
+    Scribe scribe = Scribe.of(Opportunity.class)
         .field('Id')
         .whereGreaterThanOrEqual('TotalOpportunityQuantity', value);
+
+    // null no longer throws at chain time — the error is deferred to build time,
+    // so ignoreWhen() gets a chance to retract the condition first (issue #71)
+    try {
+      scribe.toSoql();
       Assert.fail('Expected ApexEloquentException to be thrown');
     } catch (ApexEloquentException e) {
       String error = e.getMessage();
@@ -843,13 +851,17 @@ public with sharing class ScribeTest {
   }
 
   @isTest
-  static void testLessThan_WhenValueIsNull_ThenThrowException() {
+  static void testLessThan_WhenValueIsNull_ThenThrowAtBuildTime() {
     // Arrange
     Object value = null;
 
     // Act & Assert
+    Scribe scribe = Scribe.of(Opportunity.class).field('Id').whereLessThan('TotalOpportunityQuantity', null);
+
+    // null no longer throws at chain time — the error is deferred to build time,
+    // so ignoreWhen() gets a chance to retract the condition first (issue #71)
     try {
-      Scribe scribe = Scribe.of(Opportunity.class).field('Id').whereLessThan('TotalOpportunityQuantity', null);
+      scribe.toSoql();
       Assert.fail('Expected ApexEloquentException to be thrown');
     } catch (ApexEloquentException e) {
       String error = e.getMessage();
@@ -874,15 +886,19 @@ public with sharing class ScribeTest {
   }
 
   @isTest
-  static void testLessThanOrEqual_WhenValueIsNull_ThenThrowException() {
+  static void testLessThanOrEqual_WhenValueIsNull_ThenThrowAtBuildTime() {
     // Arrange
     Object value = null;
 
     // Act & Assert
-    try {
-      Scribe scribe = Scribe.of(Opportunity.class)
+    Scribe scribe = Scribe.of(Opportunity.class)
         .field('Id')
         .whereLessThanOrEqual('TotalOpportunityQuantity', value);
+
+    // null no longer throws at chain time — the error is deferred to build time,
+    // so ignoreWhen() gets a chance to retract the condition first (issue #71)
+    try {
+      scribe.toSoql();
       Assert.fail('Expected ApexEloquentException to be thrown');
     } catch (ApexEloquentException e) {
       String error = e.getMessage();
@@ -918,13 +934,17 @@ public with sharing class ScribeTest {
   }
 
   @isTest
-  static void testLike_WhenValueIsNull_ThenThrowException() {
+  static void testLike_WhenValueIsNull_ThenThrowAtBuildTime() {
     // Arrange
     Object value = null;
 
     // Act & Assert
+    Scribe scribe = Scribe.of(Account.class).field('Id').whereLike('Name', null);
+
+    // null no longer throws at chain time — the error is deferred to build time,
+    // so ignoreWhen() gets a chance to retract the condition first (issue #71)
     try {
-      Scribe scribe = Scribe.of(Account.class).field('Id').whereLike('Name', null);
+      scribe.toSoql();
       Assert.fail('Expected ApexEloquentException to be thrown');
     } catch (ApexEloquentException e) {
       String error = e.getMessage();
@@ -947,13 +967,17 @@ public with sharing class ScribeTest {
   }
 
   @isTest
-  static void testNotLike_WhenValueIsNull_ThenThrowException() {
+  static void testNotLike_WhenValueIsNull_ThenThrowAtBuildTime() {
     // Arrange
     Object value = null;
 
     // Act & Assert
+    Scribe scribe = Scribe.of(Account.class).field('Id').whereNotLike('Name', null);
+
+    // null no longer throws at chain time — the error is deferred to build time,
+    // so ignoreWhen() gets a chance to retract the condition first (issue #71)
     try {
-      Scribe scribe = Scribe.of(Account.class).field('Id').whereNotLike('Name', null);
+      scribe.toSoql();
       Assert.fail('Expected ApexEloquentException to be thrown');
     } catch (ApexEloquentException e) {
       String error = e.getMessage();
@@ -963,13 +987,17 @@ public with sharing class ScribeTest {
   }
 
   @isTest
-  static void testIn_WhenValueIsNull_ThenThrowException() {
+  static void testIn_WhenValueIsNull_ThenThrowAtBuildTime() {
     // Arrange
     Object value = null;
 
     // Act & Assert
+    Scribe scribe = Scribe.of(Account.class).field('Id').whereIn('Name', value);
+
+    // null no longer throws at chain time — the error is deferred to build time,
+    // so ignoreWhen() gets a chance to retract the condition first (issue #71)
     try {
-      Scribe scribe = Scribe.of(Account.class).field('Id').whereIn('Name', value);
+      scribe.toSoql();
       Assert.fail('Expected ApexEloquentException to be thrown');
     } catch (ApexEloquentException e) {
       String error = e.getMessage();
@@ -1035,13 +1063,17 @@ public with sharing class ScribeTest {
   }
 
   @isTest
-  static void testIn_WhenApplyNullAsSubquery_ThenThrowException() {
+  static void testIn_WhenApplyNullAsSubquery_ThenThrowAtBuildTime() {
     // Arrange
     Scribe subquery = null;
 
     // Act & Assert
+    Scribe scribe = Scribe.of(Opportunity.class).field('Id').whereIn('AccountId', subquery);
+
+    // null no longer throws at chain time — the error is deferred to build time,
+    // so ignoreWhen() gets a chance to retract the condition first (issue #71)
     try {
-      Scribe scribe = Scribe.of(Opportunity.class).field('Id').whereIn('AccountId', subquery);
+      scribe.toSoql();
       Assert.fail('Expected ApexEloquentException to be thrown');
     } catch (ApexEloquentException e) {
       String error = e.getMessage();
@@ -1084,13 +1116,17 @@ public with sharing class ScribeTest {
   }
 
   @isTest
-  static void testNotIn_WhenValueIsNull_ThenThrowException() {
+  static void testNotIn_WhenValueIsNull_ThenThrowAtBuildTime() {
     // Arrange
     Object value = null;
 
     // Act & Assert
+    Scribe scribe = Scribe.of(Account.class).field('Id').whereNotIn('Name', value);
+
+    // null no longer throws at chain time — the error is deferred to build time,
+    // so ignoreWhen() gets a chance to retract the condition first (issue #71)
     try {
-      Scribe scribe = Scribe.of(Account.class).field('Id').whereNotIn('Name', value);
+      scribe.toSoql();
       Assert.fail('Expected ApexEloquentException to be thrown');
     } catch (ApexEloquentException e) {
       String error = e.getMessage();
@@ -1159,13 +1195,17 @@ public with sharing class ScribeTest {
   }
 
   @isTest
-  static void testNotIn_WhenApplyNullAsSubquery_ThenThrowException() {
+  static void testNotIn_WhenApplyNullAsSubquery_ThenThrowAtBuildTime() {
     // Arrange
     Scribe subquery = null;
 
     // Act & Assert
+    Scribe scribe = Scribe.of(Opportunity.class).field('Id').whereNotIn('AccountId', subquery);
+
+    // null no longer throws at chain time — the error is deferred to build time,
+    // so ignoreWhen() gets a chance to retract the condition first (issue #71)
     try {
-      Scribe scribe = Scribe.of(Opportunity.class).field('Id').whereNotIn('AccountId', subquery);
+      scribe.toSoql();
       Assert.fail('Expected ApexEloquentException to be thrown');
     } catch (ApexEloquentException e) {
       String error = e.getMessage();
@@ -1208,13 +1248,17 @@ public with sharing class ScribeTest {
   }
 
   @isTest
-  static void testIncludes_WhenValueIsNull_ThenThrowException() {
+  static void testIncludes_WhenValueIsNull_ThenThrowAtBuildTime() {
     // Arrange
     List<String> value = null;
 
     // Act & Assert
+    Scribe scribe = Scribe.of(Account.class).field('Id').whereIncludes('Type', value);
+
+    // null no longer throws at chain time — the error is deferred to build time,
+    // so ignoreWhen() gets a chance to retract the condition first (issue #71)
     try {
-      Scribe scribe = Scribe.of(Account.class).field('Id').whereIncludes('Type', value);
+      scribe.toSoql();
       Assert.fail('Expected ApexEloquentException to be thrown');
     } catch (ApexEloquentException e) {
       String error = e.getMessage();
@@ -1240,13 +1284,17 @@ public with sharing class ScribeTest {
   }
 
   @isTest
-  static void testExcludes_WhenValueIsNull_ThenThrowException() {
+  static void testExcludes_WhenValueIsNull_ThenThrowAtBuildTime() {
     // Arrange
     List<String> value = null;
 
     // Act & Assert
+    Scribe scribe = Scribe.of(Account.class).field('Id').whereExcludes('Type', value);
+
+    // null no longer throws at chain time — the error is deferred to build time,
+    // so ignoreWhen() gets a chance to retract the condition first (issue #71)
     try {
-      Scribe scribe = Scribe.of(Account.class).field('Id').whereExcludes('Type', value);
+      scribe.toSoql();
       Assert.fail('Expected ApexEloquentException to be thrown');
     } catch (ApexEloquentException e) {
       String error = e.getMessage();
@@ -4123,6 +4171,269 @@ public with sharing class ScribeTest {
     } catch (ApexEloquentException e) {
       String error = e.getMessage();
       Assert.isTrue(error.contains('Ambiguous Relationship'));
+    }
+  }
+
+  // ===============================================================================
+  // Deferred null-value validation (issue #71): a null value no longer throws at
+  // chain time — an InvalidConditionClause is recorded, so a following ignoreWhen()
+  // can retract it. If it survives to toSoql(), the original required-argument
+  // error fires, naming the originating method and field.
+  // ===============================================================================
+
+  @isTest
+  static void testIgnoreWhen_WhenWhereInValuesAreNull_ThenConditionDropped() {
+    // the motivating case: 「値が null なら絞り込まない」を1チェーンで書ける
+    Set<String> names = null;
+    Scribe scribe = Scribe.of(Account.class).field('Id').whereIn('Name', names).ignoreWhen(names == null);
+
+    Assert.areEqual('SELECT id FROM Account', scribe.toSoql());
+  }
+
+  @isTest
+  static void testIgnoreWhen_WhenWhereNotInValuesAreNull_ThenConditionDropped() {
+    Set<String> names = null;
+    Scribe scribe = Scribe.of(Account.class).field('Id').whereNotIn('Name', names).ignoreWhen(names == null);
+
+    Assert.areEqual('SELECT id FROM Account', scribe.toSoql());
+  }
+
+  @isTest
+  static void testIgnoreWhen_WhenComparisonValueIsNull_ThenConditionDropped() {
+    // representative of the comparison/LIKE family (all 12 null-rejecting sites share the mechanism)
+    Object amount = null;
+    Scribe scribe = Scribe.of(Opportunity.class)
+      .field('Id')
+      .whereGreaterThan('Amount', amount)
+      .ignoreWhen(amount == null);
+
+    Assert.areEqual('SELECT id FROM Opportunity', scribe.toSoql());
+  }
+
+  @isTest
+  static void testIgnoreWhen_WhenNullConditionDroppedAmongOthers_ThenSurvivorsKeepWorking() {
+    // retraction of the invalid condition must leave a clean chain behind
+    Set<String> names = null;
+    Scribe scribe = Scribe.of(Account.class)
+      .field('Id')
+      .whereEqual('Industry', 'Tech')
+      .whereIn('Name', names)
+      .ignoreWhen(names == null)
+      .whereLike('Phone', '03-%');
+
+    Assert.areEqual('SELECT id FROM Account WHERE Industry = \'Tech\' AND Phone LIKE \'03-%\'', scribe.toSoql());
+  }
+
+  @isTest
+  static void testIgnoreWhen_WhenNullConditionInsideGroupDropped_ThenGroupIgnored() {
+    // a group whose only condition was retracted is an empty group → ignored entirely
+    Set<String> names = null;
+    Scribe scribe = Scribe.of(Account.class)
+      .field('Id')
+      .whereGroup(Scribe.asGroup().whereIn('Name', names).ignoreWhen(names == null));
+
+    Assert.areEqual('SELECT id FROM Account', scribe.toSoql());
+  }
+
+  @isTest
+  static void testWhereIn_WhenNullValuesSurviveInsideGroup_ThenThrowAtBuildTime() {
+    // an un-retracted invalid condition inside a group still fires the deferred error
+    Set<String> names = null;
+    Scribe scribe = Scribe.of(Account.class).field('Id').whereGroup(Scribe.asGroup().whereIn('Name', names));
+
+    try {
+      scribe.toSoql();
+      Assert.fail('Expected ApexEloquentException to be thrown');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('whereIn(String fieldName, Object values)'), e.getMessage());
+    }
+  }
+
+  @isTest
+  static void testWhereIn_WhenNullValuesNotIgnored_ThenErrorNamesMethodAndField() {
+    // the deferred error must keep the offending where...() identifiable
+    Set<String> names = null;
+    Scribe scribe = Scribe.of(Account.class).field('Id').whereIn('Name', names);
+
+    try {
+      scribe.toSoql();
+      Assert.fail('Expected ApexEloquentException to be thrown');
+    } catch (ApexEloquentException e) {
+      String error = e.getMessage();
+      Assert.isTrue(error.contains('whereIn(String fieldName, Object values)'), error);
+      Assert.isTrue(error.contains('Missing required parameter'), error);
+      Assert.isTrue(error.contains('Name'), 'Error must name the field: ' + error);
+      Assert.isTrue(error.contains('ignoreWhen'), 'Error must hint the retraction path: ' + error);
+    }
+  }
+
+  // ===============================================================================
+  // ignoreWhen combination matrix (issue #72): what remains after a retraction must
+  // stay a well-formed chain — across value states (normal/empty/null), groups,
+  // OR marks, and subqueries. Table-driven: one row per combination.
+  // ===============================================================================
+
+  private class MatrixCase {
+    String name;
+    Scribe scribe;
+    String expected;
+    MatrixCase(String name, Scribe scribe, String expected) {
+      this.name = name;
+      this.scribe = scribe;
+      this.expected = expected;
+    }
+  }
+
+  @isTest
+  static void testIgnoreWhenMatrix_CombinationRows_ThenExpectedSoql() {
+    Set<String> vals = new Set<String>{ 'A' };
+    Set<String> emptySet = new Set<String>();
+    Set<String> nullSet = null;
+    Scribe subQuery = Scribe.of(Account.class).field('Id').whereEqual('Name', 'X');
+    Scribe nullSubQuery = null;
+
+    List<MatrixCase> cases = new List<MatrixCase>{
+      // --- value states × whereIn/whereNotIn × ignoreWhen ---
+      new MatrixCase(
+        'in/normal/kept',
+        Scribe.of(Account.class).field('Id').whereIn('Name', vals),
+        'SELECT id FROM Account WHERE Name IN (\'A\')'
+      ),
+      new MatrixCase(
+        'in/normal/ignoreWhen(false) keeps',
+        Scribe.of(Account.class).field('Id').whereIn('Name', vals).ignoreWhen(false),
+        'SELECT id FROM Account WHERE Name IN (\'A\')'
+      ),
+      new MatrixCase(
+        'in/empty/kept = always false',
+        Scribe.of(Account.class).field('Id').whereIn('Name', emptySet),
+        'SELECT id FROM Account WHERE Id = null'
+      ),
+      new MatrixCase(
+        'notIn/empty/kept = condition ignored',
+        Scribe.of(Account.class).field('Id').whereNotIn('Name', emptySet),
+        'SELECT id FROM Account'
+      ),
+      new MatrixCase(
+        'in/empty/ignored',
+        Scribe.of(Account.class).field('Id').whereIn('Name', emptySet).ignoreWhen(true),
+        'SELECT id FROM Account'
+      ),
+      new MatrixCase(
+        'in/null/ignored',
+        Scribe.of(Account.class).field('Id').whereIn('Name', nullSet).ignoreWhen(true),
+        'SELECT id FROM Account'
+      ),
+      new MatrixCase(
+        'notIn/null/ignored',
+        Scribe.of(Account.class).field('Id').whereNotIn('Name', nullSet).ignoreWhen(true),
+        'SELECT id FROM Account'
+      ),
+      // --- OR interactions ---
+      new MatrixCase(
+        'or-mid retraction leaves A OR C',
+        Scribe.of(Account.class)
+          .field('Id')
+          .whereEqual('Industry', 'A')
+          .orCondition()
+          .whereEqual('Industry', 'B')
+          .ignoreWhen(true)
+          .orCondition()
+          .whereEqual('Industry', 'C'),
+        'SELECT id FROM Account WHERE Industry = \'A\' OR Industry = \'C\''
+      ),
+      new MatrixCase(
+        'empty-IN as OR member keeps always-false semantics',
+        Scribe.of(Account.class).field('Id').whereEqual('Industry', 'A').orCondition().whereIn('Name', emptySet),
+        'SELECT id FROM Account WHERE Industry = \'A\' OR Id = null'
+      ),
+      new MatrixCase(
+        'null-IN as OR member retracted → OR marker cleaned up',
+        Scribe.of(Account.class)
+          .field('Id')
+          .whereEqual('Industry', 'A')
+          .orCondition()
+          .whereIn('Name', nullSet)
+          .ignoreWhen(true),
+        'SELECT id FROM Account WHERE Industry = \'A\''
+      ),
+      // --- groups ---
+      new MatrixCase(
+        'group partial retraction keeps survivor',
+        Scribe.of(Account.class)
+          .field('Id')
+          .whereGroup(Scribe.asGroup().whereEqual('Industry', 'T').whereIn('Name', nullSet).ignoreWhen(true)),
+        'SELECT id FROM Account WHERE (Industry = \'T\')'
+      ),
+      new MatrixCase(
+        'group OR-member retraction → AND can follow inside group',
+        Scribe.of(Account.class)
+          .field('Id')
+          .whereGroup(
+            Scribe.asGroup()
+              .whereEqual('Industry', 'A')
+              .orCondition()
+              .whereEqual('Industry', 'B')
+              .ignoreWhen(true)
+              .whereEqual('Rating', 'C')
+          ),
+        'SELECT id FROM Account WHERE (Industry = \'A\' AND Rating = \'C\')'
+      ),
+      new MatrixCase(
+        'fully retracted group is ignored, later conditions still attach',
+        Scribe.of(Account.class)
+          .field('Id')
+          .whereGroup(Scribe.asGroup().whereIn('Name', nullSet).ignoreWhen(true))
+          .whereEqual('Industry', 'T'),
+        'SELECT id FROM Account WHERE Industry = \'T\''
+      ),
+      // --- subqueries ---
+      new MatrixCase(
+        'subquery condition retracted',
+        Scribe.of(Opportunity.class).field('Id').whereIn('AccountId', subQuery).ignoreWhen(true),
+        'SELECT id FROM Opportunity'
+      ),
+      new MatrixCase(
+        'null subquery retracted',
+        Scribe.of(Opportunity.class).field('Id').whereIn('AccountId', nullSubQuery).ignoreWhen(true),
+        'SELECT id FROM Opportunity'
+      )
+    };
+
+    for (MatrixCase c : cases) {
+      Assert.areEqual(c.expected, c.scribe.toSoql(), c.name);
+    }
+  }
+
+  @isTest
+  static void testIgnoreWhenMatrix_SurvivingInvalidRows_ThenThrowAtBuildTime() {
+    Set<String> nullSet = null;
+
+    // expected: the message names the originating method
+    List<MatrixCase> cases = new List<MatrixCase>{
+      new MatrixCase(
+        'null-IN as surviving OR member',
+        Scribe.of(Account.class).field('Id').whereEqual('Industry', 'A').orCondition().whereIn('Name', nullSet),
+        'whereIn(String fieldName, Object values)'
+      ),
+      new MatrixCase(
+        'null-NOT-IN surviving after another retraction',
+        Scribe.of(Account.class)
+          .field('Id')
+          .whereEqual('Industry', 'A')
+          .ignoreWhen(true)
+          .whereNotIn('Name', nullSet),
+        'whereNotIn(String fieldName, Object values)'
+      )
+    };
+
+    for (MatrixCase c : cases) {
+      try {
+        c.scribe.toSoql();
+        Assert.fail('Expected ApexEloquentException: ' + c.name);
+      } catch (ApexEloquentException e) {
+        Assert.isTrue(e.getMessage().contains(c.expected), c.name + ' / ' + e.getMessage());
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #71
Closes #72

## #71: null no longer defeats ignoreWhen

`whereIn(f, ids).ignoreWhen(ids == null)` threw before ever reaching `ignoreWhen()` — the 12 null-rejecting `where...()` methods validated the value at **chain time**. They now record an **`InvalidConditionClause`** placeholder (案A from #71): it behaves like any condition part, so a following `ignoreWhen()` retracts it; if it **survives to `toSoql()`**, it fires the original required-argument error, naming the originating method + field and hinting the `.ignoreWhen(...)` escape hatch.

- ✅ `whereIn(f, null)` alone still errors (strictness kept — just at build time)
- ✅ `whereIn(f, null).ignoreWhen(true)` drops the condition, matching the empty-collection behavior
- ✅ Works uniformly inside `whereGroup` scribes and for the subquery overloads (the placeholder is an ordinary condition part)
- ✏️ 12 existing chain-time-throw tests rewritten to build-time expectation (`_ThenThrowAtBuildTime`)

## #72: combination matrix

Table-driven rows over **value states (normal/empty/null) × whereIn/whereNotIn × retraction × OR marks × groups × subqueries**, in two layers:

- **SOQL-string layer** (ScribeTest): 14 combination rows + 2 surviving-invalid exception rows
- **Real-count layer** (EloquentTest, platform-frozen Group rows): 8 rows — because `whereIn(empty)` = always-false vs `whereNotIn(empty)` = condition-ignored is invisible to string comparison

**The matrix surfaced no new defects** — the v3.0.2 (stale OR-mode) and v3.1.0 (orCondition no-op) retraction fixes generalize to groups as-is. Not covered (noted in #72): retraction inside `parentCondition` / `havingCondition` scribes.

Full suite: **815 tests, 0 failures** on a Developer Edition org.

After merge: backport to `v2.2.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)