### PR TITLE
Remove sortToPreventChunkingErrors; list DML preserves caller's input order

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,12 @@ jobs:
             --set-default \
             --alias developOrg
 
+      # The repo root is now an sfdx project (sfdx-project.json for unlocked
+      # packaging), so --set-default lands in the ROOT project's local config and
+      # is invisible to ./temporaryProject where make test runs. Set it globally.
+      - name: Set default org globally
+        run: sf config set target-org developOrg --global
+
       - name: Run all Apex tests
         working-directory: ./temporaryProject
         run: make test

--- a/Eloquents/Eloquent.cls
+++ b/Eloquents/Eloquent.cls
@@ -27,8 +27,6 @@
  * @see MockEloquent
  */
 public inherited sharing class Eloquent implements IEloquent {
-  private final Integer MAX_DML_CHUNKING = 10;
-
   private static final String CLASS_NAME = 'Eloquent';
   private static final String DEFAULT_LABEL = 'default';
 
@@ -365,7 +363,6 @@ public inherited sharing class Eloquent implements IEloquent {
       if (records == null) {
         ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
       }
-      sortToPreventChunkingErrors(records);
       try {
         Database.insert(records, this.accessLevel);
       } catch (DmlException e) {
@@ -487,7 +484,6 @@ public inherited sharing class Eloquent implements IEloquent {
       if (records == null) {
         ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
       }
-      sortToPreventChunkingErrors(records);
       try {
         Database.update(records, this.accessLevel);
       } catch (DmlException e) {
@@ -511,7 +507,6 @@ public inherited sharing class Eloquent implements IEloquent {
       if (records == null) {
         ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
       }
-      sortToPreventChunkingErrors(records);
       try {
         return Database.update(records, allOrNone, this.accessLevel);
       } catch (DmlException e) {
@@ -544,7 +539,6 @@ public inherited sharing class Eloquent implements IEloquent {
       for (IEntry entry : entries) {
         records.add(entry.getRecord());
       }
-      sortToPreventChunkingErrors(records);
       try {
         Database.update(records, this.accessLevel);
       } catch (DmlException e) {
@@ -580,7 +574,6 @@ public inherited sharing class Eloquent implements IEloquent {
       for (IEntry entry : entries) {
         records.add(entry.getRecord());
       }
-      sortToPreventChunkingErrors(records);
       try {
         return Database.update(records, allOrNone, this.accessLevel);
       } catch (DmlException e) {
@@ -655,7 +648,6 @@ public inherited sharing class Eloquent implements IEloquent {
         ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
       }
 
-      sortToPreventChunkingErrors(records);
       try {
         Database.upsert(records, this.accessLevel);
       } catch (DmlException e) {
@@ -687,7 +679,6 @@ public inherited sharing class Eloquent implements IEloquent {
       for (IEntry entry : entries) {
         records.add(entry.getRecord());
       }
-      sortToPreventChunkingErrors(records);
       try {
         Database.upsert(records, this.accessLevel);
       } catch (DmlException e) {
@@ -767,7 +758,6 @@ public inherited sharing class Eloquent implements IEloquent {
         ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
       }
 
-      sortToPreventChunkingErrors(records);
       try {
         return Database.upsert(records, externalIdField, allOrNone, this.accessLevel);
       } catch (DmlException e) {
@@ -800,7 +790,6 @@ public inherited sharing class Eloquent implements IEloquent {
       for (IEntry entry : entries) {
         records.add(entry.getRecord());
       }
-      sortToPreventChunkingErrors(records);
       try {
         return Database.upsert(records, externalIdField, allOrNone, this.accessLevel);
       } catch (DmlException e) {
@@ -924,14 +913,5 @@ public inherited sharing class Eloquent implements IEloquent {
     }
 
     return ApexEloquentException.at(CLASS_NAME).error(error).reason(reason).causedBy(e);
-  }
-
-  /**
-   * @inheritDoc
-   */
-  private void sortToPreventChunkingErrors(List<SObject> records) {
-    if (records.size() >= MAX_DML_CHUNKING) {
-      records.sort();
-    }
   }
 }

--- a/Eloquents/IEloquent.cls
+++ b/Eloquents/IEloquent.cls
@@ -159,8 +159,13 @@ public interface IEloquent {
   /**
   * Inserts a list of records and returns the inserted records.
   *
+  * The returned list preserves the order of the input list.
+  * When mixing multiple SObject types in one list, group records of the same type
+  * together beforehand: Salesforce starts a new chunk at every type switch and
+  * a single DML operation fails with more than 10 chunks.
+  *
   * @param records List of SObjects to be inserted
-  * @return List of inserted SObjects
+  * @return List of inserted SObjects, in the same order as the input
   */
   List<SObject> doInsert(List<SObject> records);
 
@@ -201,34 +206,54 @@ public interface IEloquent {
   /**
   * Updates a list of records and returns the updated records.
   *
+  * The returned list preserves the order of the input list.
+  * When mixing multiple SObject types in one list, group records of the same type
+  * together beforehand: Salesforce starts a new chunk at every type switch and
+  * a single DML operation fails with more than 10 chunks.
+  *
   * @param records List of SObjects to be updated
-  * @return List of updated SObjects
+  * @return List of updated SObjects, in the same order as the input
   */
   List<SObject> doUpdate(List<SObject> records);
 
   /**
   * Updates a list of records and returns the updated records.
   *
+  * Results are returned in the same order as the input list: results[i] corresponds
+  * to records[i]. When mixing multiple SObject types in one list, group records of
+  * the same type together beforehand: Salesforce starts a new chunk at every type
+  * switch and a single DML operation fails with more than 10 chunks.
+  *
   * @param records List of SObjects to be updated
   * @param allOrNone If true, the update will be rolled back if any record fails. If false, successful updates will be committed and errors will be returned for failed records.
-  * @return List of SaveResult
+  * @return List of SaveResult, in the same order as the input
   */
   List<Database.SaveResult> doUpdate(List<SObject> records, Boolean allOrNone);
 
   /**
   * Updates a list of Entries and returns the updated Entries.
   *
+  * The returned list preserves the order of the input list.
+  * When mixing multiple SObject types in one list, group entries of the same type
+  * together beforehand: Salesforce starts a new chunk at every type switch and
+  * a single DML operation fails with more than 10 chunks.
+  *
   * @param entries List of Entries containing the SObjects to be updated
-  * @return List of updated Entries
+  * @return List of updated Entries, in the same order as the input
   */
   List<IEntry> doUpdate(List<IEntry> entries);
 
   /**
   * Updates a list of Entries and returns the updated Entries.
   *
+  * Results are returned in the same order as the input list: results[i] corresponds
+  * to entries[i]. When mixing multiple SObject types in one list, group entries of
+  * the same type together beforehand: Salesforce starts a new chunk at every type
+  * switch and a single DML operation fails with more than 10 chunks.
+  *
   * @param entries List of Entries containing the SObjects to be updated
   * @param allOrNone If true, the update will be rolled back if any record fails. If false, successful updates will be committed and errors will be returned for failed records.
-  * @return List of SaveResult
+  * @return List of SaveResult, in the same order as the input
   */
   List<Database.SaveResult> doUpdate(List<IEntry> entries, Boolean allOrNone);
 
@@ -251,16 +276,26 @@ public interface IEloquent {
   /**
   * Inserts or updates a list of records and returns the upserted records.
   *
+  * The returned list preserves the order of the input list.
+  * When mixing multiple SObject types in one list, group records of the same type
+  * together beforehand: Salesforce starts a new chunk at every type switch and
+  * a single DML operation fails with more than 10 chunks.
+  *
   * @param records List of SObjects to be upserted
-  * @return List of upserted SObjects
+  * @return List of upserted SObjects, in the same order as the input
   */
   List<SObject> doUpsert(List<SObject> records);
 
   /**
   * Inserts or updates a list of Entries and returns the upserted Entries.
   *
+  * The returned list preserves the order of the input list.
+  * When mixing multiple SObject types in one list, group entries of the same type
+  * together beforehand: Salesforce starts a new chunk at every type switch and
+  * a single DML operation fails with more than 10 chunks.
+  *
   * @param entries List of Entries containing the SObjects to be upserted
-  * @return List of upserted Entries
+  * @return List of upserted Entries, in the same order as the input
   */
   List<IEntry> doUpsert(List<IEntry> entries);
 
@@ -287,20 +322,30 @@ public interface IEloquent {
   /**
   * Inserts or updates a list of records using the specified external Id field to match existing records.
   *
+  * Results are returned in the same order as the input list: results[i] corresponds
+  * to records[i]. When mixing multiple SObject types in one list, group records of
+  * the same type together beforehand: Salesforce starts a new chunk at every type
+  * switch and a single DML operation fails with more than 10 chunks.
+  *
   * @param records List of SObjects to be upserted
   * @param externalIdField External Id field to use for matching existing records
   * @param allOrNone If true, the upsert will be rolled back if any record fails. If false, successful upserts will be committed and errors will be returned for failed records.
-  * @return List of UpsertResult
+  * @return List of UpsertResult, in the same order as the input
   */
   List<Database.UpsertResult> doUpsertByExternalId(List<SObject> records, Schema.SObjectField externalIdField, Boolean allOrNone);
 
   /**
   * Inserts or updates a list of Entries using the specified external Id field to match existing records.
   *
+  * Results are returned in the same order as the input list: results[i] corresponds
+  * to entries[i]. When mixing multiple SObject types in one list, group entries of
+  * the same type together beforehand: Salesforce starts a new chunk at every type
+  * switch and a single DML operation fails with more than 10 chunks.
+  *
   * @param entries List of Entries containing the SObjects to be upserted
   * @param externalIdField External Id field to use for matching existing records
   * @param allOrNone If true, the upsert will be rolled back if any record fails. If false, successful upserts will be committed and errors will be returned for failed records.
-  * @return List of UpsertResult
+  * @return List of UpsertResult, in the same order as the input
   */
   List<Database.UpsertResult> doUpsertByExternalId(List<IEntry> entries, Schema.SObjectField externalIdField, Boolean allOrNone);
 

--- a/Eloquents/tests/EloquentTest.cls
+++ b/Eloquents/tests/EloquentTest.cls
@@ -1365,6 +1365,99 @@ public with sharing class EloquentTest {
     Assert.areEqual(0, [SELECT COUNT() FROM Group WHERE Id = :grp.Id]);
   }
 
+  // -------------------------------------------------------------------------------
+  // Input-order preservation (issue #77)
+  // The removed sortToPreventChunkingErrors() silently reordered any list of 10+
+  // records, breaking the index correspondence between input, return value, and
+  // Database.SaveResult. These tests use 12 records in DESCENDING Name order —
+  // exactly the order an internal sort() would destroy — as a regression canary.
+  // -------------------------------------------------------------------------------
+
+  private static List<SObject> buildGroupsInDescendingNameOrder(String seed) {
+    List<SObject> records = new List<SObject>();
+    for (Integer i = 12; i >= 1; i--) {
+      records.add(buildGroup(seed + String.valueOf(i).leftPad(2, '0')));
+    }
+    return records;
+  }
+
+  @isTest
+  static void testDoInsert_WhenTwelveRecordsGiven_ThenInputOrderIsPreserved() {
+    // Arrange
+    List<SObject> records = buildGroupsInDescendingNameOrder('ordIns');
+    List<String> inputNames = new List<String>();
+    for (SObject record : records) {
+      inputNames.add((String) record.get('Name'));
+    }
+
+    // Act
+    List<SObject> inserted = (new Eloquent()).doInsert(records);
+
+    // Assert
+    Assert.areEqual(12, inserted.size());
+    for (Integer i = 0; i < inserted.size(); i++) {
+      Assert.areEqual(
+        inputNames[i],
+        (String) inserted[i].get('Name'),
+        'Returned order must match input order at index ' + i
+      );
+      Assert.isNotNull(inserted[i].Id, 'Every record must carry its assigned Id');
+    }
+  }
+
+  @isTest
+  static void testDoUpsert_WhenTwelveEntriesGiven_ThenReturnOrderMatchesInput() {
+    // Arrange
+    List<IEntry> entries = new List<IEntry>();
+    List<String> inputNames = new List<String>();
+    for (SObject record : buildGroupsInDescendingNameOrder('ordUps')) {
+      inputNames.add((String) record.get('Name'));
+      entries.add(new Entry(record));
+    }
+
+    // Act
+    List<IEntry> upserted = (new Eloquent()).doUpsert(entries);
+
+    // Assert
+    Assert.areEqual(12, upserted.size());
+    for (Integer i = 0; i < upserted.size(); i++) {
+      Assert.areEqual(
+        inputNames[i],
+        (String) upserted[i].get('Name'),
+        'entries[i] and the returned entry at [i] must be the same record'
+      );
+      Assert.isNotNull(upserted[i].getId(), 'Every returned entry must expose its assigned Id');
+    }
+  }
+
+  @isTest
+  static void testDoUpdate_WhenAllOrNoneFalseAndOneFails_ThenResultIndexMatchesInput() {
+    // Arrange - delete one record beforehand so its update fails; with 12 records
+    // the old sort() would have moved the failure to a different result index
+    List<SObject> records = buildGroupsInDescendingNameOrder('ordRes');
+    insert records;
+    Integer failedIndex = 2;
+    delete records[failedIndex];
+
+    // Act
+    List<Database.SaveResult> results = (new Eloquent()).doUpdate(records, false);
+
+    // Assert
+    Assert.areEqual(12, results.size());
+    for (Integer i = 0; i < results.size(); i++) {
+      if (i == failedIndex) {
+        Assert.isFalse(results[i].isSuccess(), 'The deleted record must fail at its own input index');
+      } else {
+        Assert.isTrue(results[i].isSuccess(), 'Record at index ' + i + ' must succeed');
+        Assert.areEqual(
+          records[i].Id,
+          results[i].getId(),
+          'SaveResult at index ' + i + ' must belong to the record at the same input index'
+        );
+      }
+    }
+  }
+
   @isTest
   static void testGet_WhenRealQuery_ThenRowsAndValuesReturned() {
     // Arrange


### PR DESCRIPTION
Fixes #77

## Problem

`sortToPreventChunkingErrors()` sorted any DML list of 10+ records even when it held a single SObject type, which can never exceed the platform's 10-chunk limit. Consequences:

- **`List<IEntry>` overloads**: the returned list / `Database.SaveResult` / `UpsertResult` came back in sorted order, silently breaking the index correspondence with the input (`entries[i]` ≠ returned `[i]`). Since `getRecord()` returns a defensive copy, the return value is the only way to obtain new record Ids — so "upsert 10+ new records and use their Ids" was broken by design.
- **`List<SObject>` overloads**: the caller's own list was destructively reordered in place.

## Fix

Remove `sortToPreventChunkingErrors` / `MAX_DML_CHUNKING` and all 9 call sites entirely. List DML now always preserves the caller's input order.

Mixed-type lists follow the platform's native chunking behavior: up to 10 chunks succeed in input order; beyond that Salesforce raises its own explicit `Cannot have more than 10 chunks` error instead of ApexEloquent silently reordering the data. The doc comments of all 9 list-accepting DML methods now state the input-order guarantee and instruct callers to pre-group mixed-type lists by SObject type.

## Tests

Three regression tests added to `EloquentTest` (real-DML section, `Group` setup object, 12 records in descending Name order — exactly the order the old `sort()` destroyed):

- `doInsert(List<SObject>)` return order matches input
- `doUpsert(List<IEntry>)` return order matches input
- `doUpdate(records, false)` with one induced failure: failing `SaveResult` index matches the input index

Verified in a Developer org: all 98 `EloquentTest` methods pass with the fix; the three new tests fail against the old v3.5.0 implementation (red-check), reproducing the issue exactly.

## Compatibility

Return order changes from "sorted when 10+ records" to "always input order" — the previous order was an unintended artifact, so this ships as a bug fix with a minor version bump (v3.6.0). Same fix will be released to the v2 maintenance line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)