### PR TITLE
Add @directory shelving tags to every class

### DIFF
--- a/AggregateClauses/AbstractAggregateClause.cls
+++ b/AggregateClauses/AbstractAggregateClause.cls
@@ -25,6 +25,7 @@
  * the specific syntax for their respective aggregate functions (e.g., `SUM`, `AVG`, `COUNT`).
  * @see IAggregateClause
  * @see Scribe
+ * @directory ApexEloquent/AggregateClauses
  */
 public with sharing abstract class AbstractAggregateClause implements IAggregateClause {
   private static final String CLASS_NAME = 'AbstractAggregateClause';

--- a/AggregateClauses/AverageClause.cls
+++ b/AggregateClauses/AverageClause.cls
@@ -22,6 +22,7 @@
  * Currency, or Percent) before building the clause.
  * @see IAggregateClause
  * @see AbstractAggregateClause
+ * @directory ApexEloquent/AggregateClauses
  */
 public with sharing class AverageClause extends AbstractAggregateClause {
   private static final String CLASS_NAME = 'AverageClause';

--- a/AggregateClauses/CountClause.cls
+++ b/AggregateClauses/CountClause.cls
@@ -23,6 +23,7 @@
  * like Boolean.
  * @see IAggregateClause
  * @see AbstractAggregateClause
+ * @directory ApexEloquent/AggregateClauses
  */
 public with sharing class CountClause extends AbstractAggregateClause {
   private static final String CLASS_NAME = 'CountClause';

--- a/AggregateClauses/CountDistinctClause.cls
+++ b/AggregateClauses/CountDistinctClause.cls
@@ -22,6 +22,7 @@
  * by the `COUNT_DISTINCT` function, preventing runtime query errors for unsupported types.
  * @see IAggregateClause
  * @see AbstractAggregateClause
+ * @directory ApexEloquent/AggregateClauses
  */
 public with sharing class CountDistinctClause extends AbstractAggregateClause {
   private static final String CLASS_NAME = 'CountDistinctClause';

--- a/AggregateClauses/IAggregateClause.cls
+++ b/AggregateClauses/IAggregateClause.cls
@@ -22,6 +22,7 @@
  * handle various aggregate functions in a polymorphic and extensible way.
  * @see AbstractAggregateClause
  * @see Scribe
+ * @directory ApexEloquent/AggregateClauses
  */
 public interface IAggregateClause {
   /**

--- a/AggregateClauses/MaxClause.cls
+++ b/AggregateClauses/MaxClause.cls
@@ -23,6 +23,7 @@
  * unsupported types like Boolean.
  * @see IAggregateClause
  * @see AbstractAggregateClause
+ * @directory ApexEloquent/AggregateClauses
  */
 public with sharing class MaxClause extends AbstractAggregateClause {
   private static final String CLASS_NAME = 'MaxClause';

--- a/AggregateClauses/MinClause.cls
+++ b/AggregateClauses/MinClause.cls
@@ -23,6 +23,7 @@
  * unsupported types like Boolean.
  * @see IAggregateClause
  * @see AbstractAggregateClause
+ * @directory ApexEloquent/AggregateClauses
  */
 public with sharing class MinClause extends AbstractAggregateClause {
   private static final String CLASS_NAME = 'MinClause';

--- a/AggregateClauses/SumClause.cls
+++ b/AggregateClauses/SumClause.cls
@@ -22,6 +22,7 @@
  * Currency, or Percent) before building the clause.
  * @see IAggregateClause
  * @see AbstractAggregateClause
+ * @directory ApexEloquent/AggregateClauses
  */
 public with sharing class SumClause extends AbstractAggregateClause {
   private static final String CLASS_NAME = 'SumClause';

--- a/ApexEloquentException.cls
+++ b/ApexEloquentException.cls
@@ -1,3 +1,6 @@
+/**
+ * @directory ApexEloquent
+ */
 public with sharing class ApexEloquentException extends Exception {
   private static final String LINE_1 = '====== APEX ELOQUENT EXCEPTION ======';
 

--- a/ConditionClauses/AbstractConditionClause.cls
+++ b/ConditionClauses/AbstractConditionClause.cls
@@ -26,6 +26,7 @@
  * specific syntax for their respective conditions (e.g., `=`, `LIKE`, `IN`).
  * @see IConditionClause
  * @see Scribe
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing abstract class AbstractConditionClause implements IConditionClause {
   private static final String CLASS_NAME = 'AbstractConditionClause';

--- a/ConditionClauses/EqualConditionClause.cls
+++ b/ConditionClauses/EqualConditionClause.cls
@@ -23,6 +23,7 @@
  * an `IS NULL` condition (e.g., `FieldName = NULL`).
  * @see IConditionClause
  * @see AbstractConditionClause
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class EqualConditionClause extends AbstractConditionClause {
   private final Object value;

--- a/ConditionClauses/ExcludeConditionClause.cls
+++ b/ConditionClauses/ExcludeConditionClause.cls
@@ -22,6 +22,7 @@
  * It formats a list of string values into the required `('value1', 'value2')` syntax.
  * @see IConditionClause
  * @see AbstractConditionClause
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class ExcludeConditionClause extends AbstractConditionClause {
   private final List<String> values;

--- a/ConditionClauses/GreaterThanConditionClause.cls
+++ b/ConditionClauses/GreaterThanConditionClause.cls
@@ -23,6 +23,7 @@
  * if the provided value is null.
  * @see IConditionClause
  * @see AbstractConditionClause
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class GreaterThanConditionClause extends AbstractConditionClause {
   private static final String CLASS_NAME = 'GreaterThanConditionClause';

--- a/ConditionClauses/GreaterThanOrEqualConditionClause.cls
+++ b/ConditionClauses/GreaterThanOrEqualConditionClause.cls
@@ -23,6 +23,7 @@
  * if the provided value is null.
  * @see IConditionClause
  * @see AbstractConditionClause
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class GreaterThanOrEqualConditionClause extends AbstractConditionClause {
   private static final String CLASS_NAME = 'GreaterThanOrEqualConditionClause';

--- a/ConditionClauses/IConditionClause.cls
+++ b/ConditionClauses/IConditionClause.cls
@@ -22,6 +22,7 @@
  * Scribe builder to handle various condition types in a polymorphic way.
  * @see AbstractConditionClause
  * @see Scribe
+ * @directory ApexEloquent/ConditionClauses
  */
  public interface IConditionClause {
   /**

--- a/ConditionClauses/InConditionClause.cls
+++ b/ConditionClauses/InConditionClause.cls
@@ -29,6 +29,7 @@
  * query correctly returns zero results.
  * @see IConditionClause
  * @see AbstractConditionClause
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class InConditionClause extends AbstractConditionClause {
   private final List<Object> values;

--- a/ConditionClauses/InSubQueryConditionClause.cls
+++ b/ConditionClauses/InSubQueryConditionClause.cls
@@ -24,6 +24,7 @@
  * @see IConditionClause
  * @see AbstractConditionClause
  * @see Scribe
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class InSubQueryConditionClause extends AbstractConditionClause {
   private final Scribe subQueryScribe;

--- a/ConditionClauses/IncludesConditionClause.cls
+++ b/ConditionClauses/IncludesConditionClause.cls
@@ -22,6 +22,7 @@
  * It formats a list of string values into the required `('value1', 'value2')` syntax.
  * @see IConditionClause
  * @see AbstractConditionClause
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class IncludesConditionClause extends AbstractConditionClause {
   private final List<String> values;

--- a/ConditionClauses/InvalidConditionClause.cls
+++ b/ConditionClauses/InvalidConditionClause.cls
@@ -26,6 +26,7 @@
  * method and field name so the offending where...() call is identifiable.
  * @see Scribe
  * @see IConditionClause
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class InvalidConditionClause implements IConditionClause {
   private static final String CLASS_NAME = 'Scribe';

--- a/ConditionClauses/IsNotNullConditionClause.cls
+++ b/ConditionClauses/IsNotNullConditionClause.cls
@@ -22,6 +22,7 @@
  * provided field name.
  * @see IConditionClause
  * @see AbstractConditionClause
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class IsNotNullConditionClause extends AbstractConditionClause {
   /**

--- a/ConditionClauses/IsNullConditionClause.cls
+++ b/ConditionClauses/IsNullConditionClause.cls
@@ -22,6 +22,7 @@
  * provided field name.
  * @see IConditionClause
  * @see AbstractConditionClause
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class IsNullConditionClause extends AbstractConditionClause {
   /**

--- a/ConditionClauses/LessThanConditionClause.cls
+++ b/ConditionClauses/LessThanConditionClause.cls
@@ -23,6 +23,7 @@
  * if the provided value is null.
  * @see IConditionClause
  * @see AbstractConditionClause
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class LessThanConditionClause extends AbstractConditionClause {
   private static final String CLASS_NAME = 'LessThanConditionClause';

--- a/ConditionClauses/LessThanOrEqualConditionClause.cls
+++ b/ConditionClauses/LessThanOrEqualConditionClause.cls
@@ -23,6 +23,7 @@
  * if the provided value is null.
  * @see IConditionClause
  * @see AbstractConditionClause
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class LessThanOrEqualConditionClause extends AbstractConditionClause {
   private static final String CLASS_NAME = 'LessThanOrEqualConditionClause';

--- a/ConditionClauses/LikeConditionClause.cls
+++ b/ConditionClauses/LikeConditionClause.cls
@@ -22,6 +22,7 @@
  * It throws an `ApexEloquentException` if the provided value is null.
  * @see IConditionClause
  * @see AbstractConditionClause
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class LikeConditionClause extends AbstractConditionClause {
   private static final String CLASS_NAME = 'LikeConditionClause';

--- a/ConditionClauses/NotEqualConditionClause.cls
+++ b/ConditionClauses/NotEqualConditionClause.cls
@@ -23,6 +23,7 @@
  * an `IS NOT NULL` condition (e.g., `FieldName != NULL`).
  * @see IConditionClause
  * @see AbstractConditionClause
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class NotEqualConditionClause extends AbstractConditionClause {
   private final Object value;

--- a/ConditionClauses/NotInConditionClause.cls
+++ b/ConditionClauses/NotInConditionClause.cls
@@ -29,6 +29,7 @@
  * condition entirely.
  * @see IConditionClause
  * @see AbstractConditionClause
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class NotInConditionClause extends AbstractConditionClause {
   private final List<Object> values;

--- a/ConditionClauses/NotInSubQueryConditionClause.cls
+++ b/ConditionClauses/NotInSubQueryConditionClause.cls
@@ -24,6 +24,7 @@
  * @see IConditionClause
  * @see AbstractConditionClause
  * @see Scribe
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class NotInSubQueryConditionClause extends AbstractConditionClause {
   private final Scribe subQueryScribe;

--- a/ConditionClauses/NotLikeConditionClause.cls
+++ b/ConditionClauses/NotLikeConditionClause.cls
@@ -23,6 +23,7 @@
  * It throws an `ApexEloquentException` if the provided value is null.
  * @see IConditionClause
  * @see AbstractConditionClause
+ * @directory ApexEloquent/ConditionClauses
  */
 public with sharing class NotLikeConditionClause extends AbstractConditionClause {
   private static final String CLASS_NAME = 'NotLikeConditionClause';

--- a/ConditionClauses/tests/EqualConditionClauseTest.cls
+++ b/ConditionClauses/tests/EqualConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class EqualConditionClauseTest {

--- a/ConditionClauses/tests/ExcludeConditionClauseTest.cls
+++ b/ConditionClauses/tests/ExcludeConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class ExcludeConditionClauseTest {

--- a/ConditionClauses/tests/GreaterThanConditionClauseTest.cls
+++ b/ConditionClauses/tests/GreaterThanConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class GreaterThanConditionClauseTest {

--- a/ConditionClauses/tests/GreaterThanOrEqualConditionClauseTest.cls
+++ b/ConditionClauses/tests/GreaterThanOrEqualConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class GreaterThanOrEqualConditionClauseTest {

--- a/ConditionClauses/tests/InConditionClauseTest.cls
+++ b/ConditionClauses/tests/InConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class InConditionClauseTest {

--- a/ConditionClauses/tests/InSubQueryConditionClauseTest.cls
+++ b/ConditionClauses/tests/InSubQueryConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class InSubQueryConditionClauseTest {

--- a/ConditionClauses/tests/IncludesConditionClauseTest.cls
+++ b/ConditionClauses/tests/IncludesConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class IncludesConditionClauseTest {

--- a/ConditionClauses/tests/IsNotNullConditionClauseTest.cls
+++ b/ConditionClauses/tests/IsNotNullConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class IsNotNullConditionClauseTest {

--- a/ConditionClauses/tests/IsNullConditionClauseTest.cls
+++ b/ConditionClauses/tests/IsNullConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class IsNullConditionClauseTest {

--- a/ConditionClauses/tests/LessThanConditionClauseTest.cls
+++ b/ConditionClauses/tests/LessThanConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class LessThanConditionClauseTest {

--- a/ConditionClauses/tests/LessThanOrEqualConditionClauseTest.cls
+++ b/ConditionClauses/tests/LessThanOrEqualConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class LessThanOrEqualConditionClauseTest {

--- a/ConditionClauses/tests/LikeConditionClauseTest.cls
+++ b/ConditionClauses/tests/LikeConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class LikeConditionClauseTest {

--- a/ConditionClauses/tests/NotEqualConditionClauseTest.cls
+++ b/ConditionClauses/tests/NotEqualConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class NotEqualConditionClauseTest {

--- a/ConditionClauses/tests/NotInConditionClauseTest.cls
+++ b/ConditionClauses/tests/NotInConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class NotInConditionClauseTest {

--- a/ConditionClauses/tests/NotInSubQueryConditionClauseTest.cls
+++ b/ConditionClauses/tests/NotInSubQueryConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class NotInSubQueryConditionClauseTest {

--- a/ConditionClauses/tests/NotLikeConditionClauseTest.cls
+++ b/ConditionClauses/tests/NotLikeConditionClauseTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/ConditionClauses/tests
  */
 @isTest
 public class NotLikeConditionClauseTest {

--- a/Eloquents/Eloquent.cls
+++ b/Eloquents/Eloquent.cls
@@ -25,6 +25,7 @@
  * @see Scribe
  * @see Entry
  * @see MockEloquent
+ * @directory ApexEloquent/Eloquents
  */
 public inherited sharing class Eloquent implements IEloquent {
   private static final String CLASS_NAME = 'Eloquent';

--- a/Eloquents/IEloquent.cls
+++ b/Eloquents/IEloquent.cls
@@ -24,6 +24,7 @@
  * @see Scribe
  * @see Eloquent
  * @see MockEloquent
+ * @directory ApexEloquent/Eloquents
  */
 public interface IEloquent {
   /**

--- a/Eloquents/MockEloquent.cls
+++ b/Eloquents/MockEloquent.cls
@@ -29,6 +29,7 @@
  * @see IEloquent
  * @see Eloquent
  * @see MockEntry
+ * @directory ApexEloquent/Eloquents
  */
 public with sharing class MockEloquent implements IEloquent {
   private static final String DEFAULT_LABEL = 'default';

--- a/Eloquents/tests/EloquentTest.cls
+++ b/Eloquents/tests/EloquentTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/Eloquents/tests
  */
 @isTest
 public with sharing class EloquentTest {

--- a/Eloquents/tests/MockEloquentTest.cls
+++ b/Eloquents/tests/MockEloquentTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/Eloquents/tests
  */
 @isTest
 public with sharing class MockEloquentTest {

--- a/Entries/AbstractEntry.cls
+++ b/Entries/AbstractEntry.cls
@@ -20,6 +20,7 @@
  * like `Entry` (for real SObjects) and `MockEntry` (for test data).
  * This class handles the dual nature of query results, capable of representing both
  * standard `SObject` records and `AggregateResult` records.
+ * @directory ApexEloquent/Entries
  */
 public abstract class AbstractEntry implements IEntry {
   private static final String CLASS_NAME = 'AbstractEntry';

--- a/Entries/Entry.cls
+++ b/Entries/Entry.cls
@@ -27,6 +27,7 @@
  * @see IEntry
  * @see AbstractEntry
  * @see MockEntry
+ * @directory ApexEloquent/Entries
  */
 public with sharing class Entry extends AbstractEntry {
   private static final String CLASS_NAME = 'Entry';

--- a/Entries/IEntry.cls
+++ b/Entries/IEntry.cls
@@ -24,6 +24,7 @@
  *
  * It provides methods to access field values and to navigate eager-loaded parent, child,
  * and many-to-many (`through`) relationships.
+ * @directory ApexEloquent/Entries
  */
 public interface IEntry {
   /**

--- a/Entries/MockEntry.cls
+++ b/Entries/MockEntry.cls
@@ -31,6 +31,7 @@
  * @see IEntry
  * @see AbstractEntry
  * @see Entry
+ * @directory ApexEloquent/Entries
  */
 public with sharing class MockEntry extends AbstractEntry {
   private final Map<String, Object> fieldToValue;

--- a/Entries/tests/EntryTest.cls
+++ b/Entries/tests/EntryTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/Entries/tests
  */
 @isTest
 public with sharing class EntryTest {

--- a/Entries/tests/MockEntryTest.cls
+++ b/Entries/tests/MockEntryTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/Entries/tests
  */
 @isTest
 public class MockEntryTest {

--- a/FieldStructure.cls
+++ b/FieldStructure.cls
@@ -26,6 +26,7 @@
  * It acts as a blueprint of the original query, allowing `MockEntry` to accurately
  * simulate the "select-forgotten" validation and ensure that tests are only accessing
  * data that would have been retrieved by the real query.
+ * @directory ApexEloquent
  */
 public with sharing class FieldStructure {
   private List<String> fields;

--- a/Scribe.cls
+++ b/Scribe.cls
@@ -19,6 +19,7 @@
  * Scribe allows developers to construct complex SOQL queries programmatically
  * without string concatenation, reducing errors and improving readability.
  * It is the core of the ApexEloquent ORM's query building capabilities.
+ * @directory ApexEloquent
  */
 public with sharing class Scribe {
   private static final String CLASS_NAME = 'Scribe';

--- a/tests/FieldStructureTest.cls
+++ b/tests/FieldStructureTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/tests
  */
 @isTest
 public with sharing class FieldStructureTest {

--- a/tests/ScribeTest.cls
+++ b/tests/ScribeTest.cls
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * @directory ApexEloquent/tests
  */
 @isTest(seeAllData=false)
 public with sharing class ScribeTest {


### PR DESCRIPTION
Every class now carries an `@directory ApexEloquent/<path>` tag in the doc comment bound to its top-level declaration, stamped by [ApexLibrarian](https://github.com/krile136/ApexLibrarian).

## Why

Orgs have no folder concept for Apex classes. Consumers who install the unlocked package and retrieve the source get all 59 classes flat in `classes/`. Doc comments travel with the class through the org, so the tag lets them reconstruct the layout under `classes/ApexEloquent/...` — identical to the git-submodule install location — with one command:

```bash
npx apex-librarian arrange
```

The tag value is simply the class's real location in a consumer checkout (submodule at `classes/ApexEloquent/`), stamped as-is with `apex-librarian stamp --include-submodules`.

## Changes

- 59 files, comment-only (+61 lines): `@directory` appended to each class's doc block; `ApexEloquentException.cls` (which had no doc block) got a minimal one
- Verified: `check --include-submodules` green across 101 classes in the consumer project; stamp is idempotent; deploy compiles clean; retrieve round-trip demo reconstructs `ApexEloquent/Eloquents/tests/` exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)