### PR TITLE
fix: mock/production fidelity — Id handling (#81, #82) + DML failure parity

### DIFF
--- a/Eloquents/MockEloquent.cls
+++ b/Eloquents/MockEloquent.cls
@@ -912,12 +912,15 @@ public with sharing class MockEloquent implements IEloquent {
         ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
       }
 
+      // Mirror Eloquent: the caller's entry stays untouched and the Id is carried
+      // by the returned Entry, exactly as Database.upsert writes it back to the
+      // clone that Eloquent wraps into its return value.
       SObject record = entry.getRecord();
       if (record.Id == null) {
-        entry.put('Id', this.generateId(record));
+        record.Id = this.generateId(record);
       }
       this.recordUpsert(label, record);
-      return entry;
+      return new Entry(record);
     } catch (Exception e) {
       this.releaseLabel(label);
       throw e;
@@ -973,6 +976,9 @@ public with sharing class MockEloquent implements IEloquent {
         ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
       }
 
+      // Mirror Eloquent: return fresh Entry instances carrying the Ids instead of
+      // mutating and aliasing the caller's entries.
+      List<IEntry> upsertedEntries = new List<IEntry>();
       for (IEntry entry : entries) {
         if (entry == null || entry.getRecord() == null) {
           String error = 'Null entry found in entries list';
@@ -988,11 +994,12 @@ public with sharing class MockEloquent implements IEloquent {
         }
         SObject record = entry.getRecord();
         if (record.Id == null) {
-          entry.put('Id', this.generateId(record));
+          record.Id = this.generateId(record);
         }
         this.recordUpsert(label, record);
+        upsertedEntries.add(new Entry(record));
       }
-      return entries;
+      return upsertedEntries;
     } catch (Exception e) {
       this.releaseLabel(label);
       throw e;
@@ -1058,7 +1065,9 @@ public with sharing class MockEloquent implements IEloquent {
       }
       Boolean isCreated = record.Id == null;
       if (isCreated) {
-        entry.put('Id', this.generateId(record));
+        // Mirror Eloquent: the Id is reported through the UpsertResult, never
+        // written back into the caller's entry (Database.upsert writes to the clone).
+        record.Id = this.generateId(record);
       }
       this.recordUpsert(label, record);
       return buildSuccessUpsertResult(record.Id, isCreated);
@@ -1159,7 +1168,9 @@ public with sharing class MockEloquent implements IEloquent {
         }
         Boolean isCreated = record.Id == null;
         if (isCreated) {
-          entry.put('Id', this.generateId(record));
+          // Mirror Eloquent: the Id is reported through the UpsertResult, never
+          // written back into the caller's entry (Database.upsert writes to the clone).
+          record.Id = this.generateId(record);
         }
         this.recordUpsert(label, record);
         results.add(buildSuccessUpsertResult(record.Id, isCreated));

--- a/Eloquents/MockEloquent.cls
+++ b/Eloquents/MockEloquent.cls
@@ -605,6 +605,9 @@ public with sharing class MockEloquent implements IEloquent {
       if (record == null) {
         ApexEloquentException.required(CLASS_NAME, method, 'record', record).fire();
       }
+      if (record.Id != null) {
+        this.fireInsertWithIdError(method, record.Id);
+      }
 
       record.Id = this.generateId(record);
       this.recordUpsert(label, record);
@@ -627,6 +630,9 @@ public with sharing class MockEloquent implements IEloquent {
         ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
       }
       for (SObject record : records) {
+        if (record.Id != null) {
+          this.fireInsertWithIdError(method, record.Id);
+        }
         record.Id = this.generateId(record);
       }
       this.recordUpsertAll(label, records);
@@ -647,6 +653,9 @@ public with sharing class MockEloquent implements IEloquent {
       this.handleErrorQueue(method, label);
       if (record == null) {
         ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
+      }
+      if (record.Id == null) {
+        this.fireUpdateWithoutIdError(method);
       }
 
       this.recordUpsert(label, record);
@@ -669,8 +678,14 @@ public with sharing class MockEloquent implements IEloquent {
         ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
       }
 
-      this.recordUpsert(label, entry.getRecord());
-      return entry;
+      SObject record = entry.getRecord();
+      if (record.Id == null) {
+        this.fireUpdateWithoutIdError(method);
+      }
+      this.recordUpsert(label, record);
+      // Mirror Eloquent: return a fresh Entry wrapping the updated clone instead of
+      // aliasing the caller's entry.
+      return new Entry(record);
     } catch (Exception e) {
       this.releaseLabel(label);
       throw e;
@@ -689,6 +704,11 @@ public with sharing class MockEloquent implements IEloquent {
         ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
       }
 
+      for (SObject record : records) {
+        if (record.Id == null) {
+          this.fireUpdateWithoutIdError(method);
+        }
+      }
       this.recordUpsertAll(label, records);
       return records;
     } catch (Exception e) {
@@ -709,11 +729,19 @@ public with sharing class MockEloquent implements IEloquent {
         ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
       }
 
+      // Mirror Eloquent: return fresh Entry instances wrapping the updated clones
+      // instead of aliasing the caller's entries.
+      List<IEntry> updatedEntries = new List<IEntry>();
       for (IEntry entry : entries) {
-        this.recordUpsert(label, entry.getRecord());
+        SObject record = entry.getRecord();
+        if (record.Id == null) {
+          this.fireUpdateWithoutIdError(method);
+        }
+        this.recordUpsert(label, record);
+        updatedEntries.add(new Entry(record));
       }
 
-      return entries;
+      return updatedEntries;
     } catch (Exception e) {
       this.releaseLabel(label);
       throw e;
@@ -732,6 +760,14 @@ public with sharing class MockEloquent implements IEloquent {
         ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
       }
 
+      if (record.Id == null) {
+        // Real Database.update throws for allOrNone=true and returns a row-level
+        // MISSING_ARGUMENT failure for allOrNone=false.
+        if (allOrNone == true) {
+          this.fireUpdateWithoutIdError(method);
+        }
+        return buildMissingIdSaveResult();
+      }
       if (allOrNone == true) {
         this.enforceAllOrNone(method, record);
       }
@@ -758,6 +794,14 @@ public with sharing class MockEloquent implements IEloquent {
       }
 
       SObject record = entry.getRecord();
+      if (record.Id == null) {
+        // Real Database.update throws for allOrNone=true and returns a row-level
+        // MISSING_ARGUMENT failure for allOrNone=false.
+        if (allOrNone == true) {
+          this.fireUpdateWithoutIdError(method);
+        }
+        return buildMissingIdSaveResult();
+      }
       if (allOrNone == true) {
         this.enforceAllOrNone(method, record);
       }
@@ -785,11 +829,20 @@ public with sharing class MockEloquent implements IEloquent {
 
       if (allOrNone == true) {
         for (SObject record : records) {
+          if (record.Id == null) {
+            this.fireUpdateWithoutIdError(method);
+          }
           this.enforceAllOrNone(method, record);
         }
       }
       List<Database.SaveResult> results = new List<Database.SaveResult>();
       for (SObject record : records) {
+        if (record.Id == null) {
+          // Reachable only with allOrNone=false: real Database.update reports a
+          // row-level MISSING_ARGUMENT failure and processes the other rows.
+          results.add(buildMissingIdSaveResult());
+          continue;
+        }
         if (!this.isSaveFailure(record)) {
           this.recordUpsert(label, record);
         }
@@ -816,12 +869,22 @@ public with sharing class MockEloquent implements IEloquent {
 
       if (allOrNone == true) {
         for (IEntry entry : entries) {
-          this.enforceAllOrNone(method, entry.getRecord());
+          SObject checked = entry.getRecord();
+          if (checked.Id == null) {
+            this.fireUpdateWithoutIdError(method);
+          }
+          this.enforceAllOrNone(method, checked);
         }
       }
       List<Database.SaveResult> results = new List<Database.SaveResult>();
       for (IEntry entry : entries) {
         SObject record = entry.getRecord();
+        if (record.Id == null) {
+          // Reachable only with allOrNone=false: real Database.update reports a
+          // row-level MISSING_ARGUMENT failure and processes the other rows.
+          results.add(buildMissingIdSaveResult());
+          continue;
+        }
         if (!this.isSaveFailure(record)) {
           this.recordUpsert(label, record);
         }
@@ -875,6 +938,63 @@ public with sharing class MockEloquent implements IEloquent {
     String idPart = recordId == null ? '' : '"id":"' + recordId + '",';
     String payload = '{"success":true,' + idPart + '"errors":[]}';
     return (Database.SaveResult) JSON.deserialize(payload, Database.SaveResult.class);
+  }
+
+  /**
+   * Build the failed SaveResult that real Database.update returns for a record
+   * without an Id when allOrNone is false (row-level MISSING_ARGUMENT error).
+   *
+   * @return failed SaveResult carrying the MISSING_ARGUMENT error
+   */
+  private static Database.SaveResult buildMissingIdSaveResult() {
+    String payload = '{"success":false,"errors":[{"message":"Id not specified in an update call","statusCode":"MISSING_ARGUMENT"}]}';
+    return (Database.SaveResult) JSON.deserialize(payload, Database.SaveResult.class);
+  }
+
+  /**
+   * Fire the mock counterpart of the platform error thrown when a record that
+   * already has an Id is passed to Database.insert (INVALID_FIELD_FOR_INSERT_UPDATE).
+   *
+   * @param method calling method signature
+   * @param recordId Id found on the record
+   */
+  private void fireInsertWithIdError(String method, Id recordId) {
+    String error = 'Failed to insert operation';
+    String reason = 'cannot specify Id in an insert call: real Database.insert throws INVALID_FIELD_FOR_INSERT_UPDATE for records that already have an Id';
+    String action = 'Remove the Id from the record, or use doUpdate / doUpsert instead';
+    ApexEloquentException.at(CLASS_NAME)
+      .method(method)
+      .error(error)
+      .reason(reason)
+      .action(action)
+      .param('recordId', recordId)
+      .fire();
+  }
+
+  /**
+   * Fire the mock counterpart of the platform error thrown when a record
+   * without an Id is passed to Database.update (MISSING_ARGUMENT).
+   *
+   * @param method calling method signature
+   */
+  private void fireUpdateWithoutIdError(String method) {
+    String error = 'Failed to update operation';
+    String reason = 'Id not specified in an update call: real Database.update throws MISSING_ARGUMENT for records without an Id';
+    String action = 'Set the Id on the record before updating, or use doInsert / doUpsert instead';
+    ApexEloquentException.at(CLASS_NAME).method(method).error(error).reason(reason).action(action).fire();
+  }
+
+  /**
+   * Fire the mock counterpart of the platform error thrown when a record
+   * without an Id is passed to Database.delete (invalid ID: null).
+   *
+   * @param method calling method signature
+   */
+  private void fireDeleteWithoutIdError(String method) {
+    String error = 'Failed to delete operation';
+    String reason = 'invalid Id: null — real Database.delete throws for records without an Id';
+    String action = 'Set the Id on the record before deleting';
+    ApexEloquentException.at(CLASS_NAME).method(method).error(error).reason(reason).action(action).fire();
   }
 
   /**
@@ -1214,6 +1334,9 @@ public with sharing class MockEloquent implements IEloquent {
       if (record == null) {
         ApexEloquentException.required(CLASS_NAME, method, 'record', null).fire();
       }
+      if (record.Id == null) {
+        this.fireDeleteWithoutIdError(method);
+      }
 
       this.recordDelete(label, 1);
       return;
@@ -1233,6 +1356,9 @@ public with sharing class MockEloquent implements IEloquent {
       this.handleErrorQueue(method, label);
       if (entry == null) {
         ApexEloquentException.required(CLASS_NAME, method, 'entry', null).fire();
+      }
+      if (entry.getRecord() == null || entry.getRecord().Id == null) {
+        this.fireDeleteWithoutIdError(method);
       }
 
       this.recordDelete(label, 1);
@@ -1254,6 +1380,11 @@ public with sharing class MockEloquent implements IEloquent {
       if (records == null) {
         ApexEloquentException.required(CLASS_NAME, method, 'records', null).fire();
       }
+      for (SObject record : records) {
+        if (record == null || record.Id == null) {
+          this.fireDeleteWithoutIdError(method);
+        }
+      }
 
       this.recordDelete(label, records.size());
       return;
@@ -1273,6 +1404,11 @@ public with sharing class MockEloquent implements IEloquent {
       this.handleErrorQueue(method, label);
       if (entries == null) {
         ApexEloquentException.required(CLASS_NAME, method, 'entries', null).fire();
+      }
+      for (IEntry entry : entries) {
+        if (entry == null || entry.getRecord() == null || entry.getRecord().Id == null) {
+          this.fireDeleteWithoutIdError(method);
+        }
       }
 
       this.recordDelete(label, entries.size());

--- a/Eloquents/tests/MockEloquentTest.cls
+++ b/Eloquents/tests/MockEloquentTest.cls
@@ -3593,4 +3593,136 @@ public with sharing class MockEloquentTest {
       Assert.areEqual('boom', e.getMessage());
     }
   }
+
+  // ---- platform-fidelity guards: the mock must fail where real DML fails ----
+
+  @isTest
+  static void testDoInsert_WhenRecordHasId_ThenThrowException() {
+    // Arrange
+    IEloquent eloquent = new MockEloquent();
+    Account record = new Account(Id = '001000000000001AAA', Name = 'Test');
+
+    // Act & Assert
+    // Real Database.insert throws INVALID_FIELD_FOR_INSERT_UPDATE for records with an Id.
+    try {
+      eloquent.doInsert(record);
+      Assert.fail('Expected ApexEloquentException for insert with Id.');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('cannot specify Id in an insert call'));
+    }
+  }
+
+  @isTest
+  static void testDoInsert_WhenListContainsRecordWithId_ThenThrowException() {
+    // Arrange
+    IEloquent eloquent = new MockEloquent();
+    List<SObject> records = new List<SObject>{
+      new Account(Name = 'Fresh'),
+      new Account(Id = '001000000000001AAA', Name = 'Stale')
+    };
+
+    // Act & Assert
+    try {
+      eloquent.doInsert(records);
+      Assert.fail('Expected ApexEloquentException for insert with Id.');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('cannot specify Id in an insert call'));
+    }
+  }
+
+  @isTest
+  static void testDoUpdate_WhenRecordWithoutId_ThenThrowException() {
+    // Arrange
+    IEloquent eloquent = new MockEloquent();
+
+    // Act & Assert
+    // Real Database.update throws MISSING_ARGUMENT for records without an Id.
+    try {
+      eloquent.doUpdate(new Account(Name = 'no id'));
+      Assert.fail('Expected ApexEloquentException for update without Id.');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('Id not specified in an update call'));
+    }
+  }
+
+  @isTest
+  static void testDoUpdate_WhenEntryWithoutId_ThenThrowException() {
+    // Arrange
+    IEloquent eloquent = new MockEloquent();
+    MockEntry mockEntry = MockEntry.of(Account.class);
+
+    // Act & Assert
+    try {
+      eloquent.doUpdate(mockEntry);
+      Assert.fail('Expected ApexEloquentException for update without Id.');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('Id not specified in an update call'));
+    }
+  }
+
+  @isTest
+  static void testDoUpdate_WhenAllOrNoneFalseAndRecordWithoutId_ThenRowLevelFailure() {
+    // Arrange
+    IEloquent eloquent = new MockEloquent();
+    List<SObject> records = new List<SObject>{
+      new Account(Id = '001000000000001AAA', Name = 'good'),
+      new Account(Name = 'no id')
+    };
+
+    // Act
+    List<Database.SaveResult> results = eloquent.doUpdate(records, false);
+
+    // Assert
+    // Real Database.update with allOrNone=false reports a row-level MISSING_ARGUMENT
+    // failure for the Id-less record and still processes the other rows.
+    Assert.isTrue(results[0].isSuccess(), 'Row with Id must succeed.');
+    Assert.isFalse(results[1].isSuccess(), 'Row without Id must fail.');
+    Assert.areEqual(StatusCode.MISSING_ARGUMENT, results[1].getErrors()[0].getStatusCode());
+  }
+
+  @isTest
+  static void testDoUpdate_WhenAddEntryWithId_ThenReturnFreshEntryInstance() {
+    // Arrange
+    IEloquent eloquent = new MockEloquent();
+    MockEntry mockEntry = MockEntry.of(Account.class).autoId(1);
+
+    // Act
+    IEntry updatedEntry = eloquent.doUpdate(mockEntry);
+
+    // Assert
+    // Mirror Eloquent: a fresh Entry wrapping the updated clone comes back instead
+    // of the caller's entry instance.
+    Assert.isFalse(updatedEntry === mockEntry, 'Returned entry must not alias the input entry.');
+    Assert.areEqual(mockEntry.getId(), updatedEntry.getId(), 'Returned entry must carry the same Id.');
+  }
+
+  @isTest
+  static void testDoDelete_WhenRecordWithoutId_ThenThrowException() {
+    // Arrange
+    IEloquent eloquent = new MockEloquent();
+
+    // Act & Assert
+    // Real Database.delete throws for records without an Id.
+    try {
+      eloquent.doDelete(new Account(Name = 'no id'));
+      Assert.fail('Expected ApexEloquentException for delete without Id.');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('real Database.delete throws'));
+    }
+  }
+
+  @isTest
+  static void testDoDelete_WhenEntryWithoutId_ThenThrowException() {
+    // Arrange
+    IEloquent eloquent = new MockEloquent();
+    MockEntry mockEntry = MockEntry.of(Account.class);
+
+    // Act & Assert
+    try {
+      eloquent.doDelete(mockEntry);
+      Assert.fail('Expected ApexEloquentException for delete without Id.');
+    } catch (ApexEloquentException e) {
+      Assert.isTrue(e.getMessage().contains('real Database.delete throws'));
+    }
+  }
 }

--- a/Eloquents/tests/MockEloquentTest.cls
+++ b/Eloquents/tests/MockEloquentTest.cls
@@ -473,7 +473,7 @@ public with sharing class MockEloquentTest {
   }
 
   @isTest
-  static void testGet_WhenEntryWithNestedParentGetNonSelectedField_ThenThrowException() {
+  static void testGet_WhenEntryWithNestedParentGetId_ThenReturnIdWithoutScribeDeclaration() {
     // Arrange
     SObject record = new OrderItem();
     FieldStructure FieldStructure = new FieldStructure(
@@ -541,15 +541,13 @@ public with sharing class MockEloquentTest {
     IEntry grandparentEntry = parentEntry.getParent('ParentId');
 
     // Assert
-    try {
-      grandparentEntry.getId(); // This field is not selected in the Scribe query
-      Assert.fail('Expected ApexEloquentException to be thrown for non-selected field in nested parent');
-    } catch (ApexEloquentException e) {
-      String error = e.getMessage();
-      Assert.isTrue(error.contains('The specified field is not selected in Scribe'));
-      Assert.isTrue(error.contains('[objectName => \'Account\']'));
-      Assert.isTrue(error.contains('[fieldName => \'Id\']'));
-    }
+    // Real SOQL returns the Id of a traversed parent even when it is not listed in
+    // the SELECT clause, so the mock must not require a Scribe declaration for it.
+    Assert.areEqual(
+      '001000000000000001',
+      grandparentEntry.getId(),
+      'Id of a nested parent should be readable without a Scribe declaration.'
+    );
   }
 
   @isTest
@@ -606,7 +604,7 @@ public with sharing class MockEloquentTest {
   }
 
   @isTest
-  static void testGet_WhenEntryWithNestedChildrenGetNonSelectedField_ThenThrowException() {
+  static void testGet_WhenEntryWithNestedChildrenGetId_ThenReadableWithoutScribeDeclaration() {
     // Arrange
     List<String> nameFields = new List<String>{ 'Name' };
     List<String> caseFields = new List<String>{ 'Subject' };
@@ -662,16 +660,11 @@ public with sharing class MockEloquentTest {
     List<IEntry> grandchildCases1 = childCases1[0].getChildren('Case');
 
     // Assert
-    try {
-      for (IEntry grandchildCase : grandchildCases1) {
-        grandchildCase.getId(); // This field is not selected in the Scribe query
-        Assert.fail('Expected ApexEloquentException to be thrown for non-selected field in nested child');
-      }
-    } catch (ApexEloquentException e) {
-      String error = e.getMessage();
-      Assert.isTrue(error.contains('The specified field is not selected in Scribe'));
-      Assert.isTrue(error.contains('[objectName => \'Case\']'));
-      Assert.isTrue(error.contains('[fieldName => \'Id\']'));
+    // Real SOQL returns the Id of subquery rows even when it is not listed in the
+    // SELECT clause, so reading Id must not require a Scribe declaration. The mock
+    // data sets no Id, so null comes back instead of an exception.
+    for (IEntry grandchildCase : grandchildCases1) {
+      Assert.isNull(grandchildCase.getId(), 'Id must be readable without a Scribe declaration.');
     }
   }
 
@@ -2039,6 +2032,22 @@ public with sharing class MockEloquentTest {
   }
 
   @isTest
+  static void testDoUpsert_WhenAddEntryWithoutId_ThenInputEntryNotMutated() {
+    // Arrange
+    MockEntry mockEntry = MockEntry.of(Opportunity.class);
+    IEloquent eloquent = new MockEloquent();
+
+    // Act
+    IEntry upsertedEntry = eloquent.doUpsert(mockEntry);
+
+    // Assert
+    // Mirror Eloquent: Database.upsert writes the Id back to the internal clone, so
+    // the caller's entry stays untouched and the Id is carried by the returned Entry.
+    Assert.isNull(mockEntry.getId(), 'Input entry must not be mutated by the mock.');
+    Assert.isNotNull(upsertedEntry.getId(), 'Returned entry must carry the generated Id.');
+  }
+
+  @isTest
   static void testDoUpsert_WhenAddNullListOfSObject_ThenThrowException() {
     // Arrange
     IEloquent eloquent = new MockEloquent();
@@ -2110,6 +2119,31 @@ public with sharing class MockEloquentTest {
       IEntry entry = upsertedEntries[i];
       Assert.isNotNull(entry.getId(), 'Expected each entry to have an Id after upsert');
     }
+  }
+
+  @isTest
+  static void testDoUpsert_WhenAddEntriesWithoutId_ThenReturnNewEntriesAndInputNotMutated() {
+    // Arrange
+    List<MockEntry> mockEntries = new List<MockEntry>{
+      MockEntry.of(Opportunity.class),
+      MockEntry.of(Opportunity.class)
+    };
+    IEloquent eloquent = new MockEloquent();
+
+    // Act
+    List<IEntry> upsertedEntries = eloquent.doUpsert(mockEntries);
+
+    // Assert
+    // Mirror Eloquent: fresh Entry instances carry the Ids; the caller's entries stay untouched.
+    for (Integer i = 0; i < mockEntries.size(); i++) {
+      Assert.isNull(mockEntries[i].getId(), 'Input entries must not be mutated by the mock.');
+      Assert.isNotNull(upsertedEntries[i].getId(), 'Returned entries must carry the generated Ids.');
+    }
+    Assert.areNotEqual(
+      upsertedEntries[0].getId(),
+      upsertedEntries[1].getId(),
+      'Each created record must receive a distinct Id.'
+    );
   }
 
   @isTest
@@ -2322,6 +2356,48 @@ public with sharing class MockEloquentTest {
     Assert.isTrue(results[0].isCreated(), 'Expected first isCreated to be true (no Id)');
     Assert.isTrue(results[1].isSuccess(), 'Expected second UpsertResult to be success');
     Assert.isFalse(results[1].isCreated(), 'Expected second isCreated to be false (auto Id assigned)');
+  }
+
+  @isTest
+  static void testDoUpsertByExternalId_WhenEntryWithoutId_ThenResultCarriesIdAndEntryNotMutated() {
+    // Arrange
+    MockEntry mockEntry = MockEntry.of(Opportunity.class);
+    IEloquent eloquent = new MockEloquent();
+
+    // Act
+    Database.UpsertResult result = eloquent.doUpsertByExternalId(mockEntry, Opportunity.Id, false);
+
+    // Assert
+    // Mirror Eloquent: Database.upsert reports the Id through the UpsertResult and
+    // never writes it back into the caller's entry (it lands on the internal clone).
+    Assert.isTrue(result.isCreated(), 'Expected isCreated to be true for entry without Id');
+    Assert.isNotNull(result.getId(), 'UpsertResult must carry the generated Id.');
+    Assert.isNull(mockEntry.getId(), 'Input entry must not be mutated by the mock.');
+  }
+
+  @isTest
+  static void testDoUpsertByExternalId_WhenEntriesWithoutId_ThenResultsAndRecordsCarryIds() {
+    // Arrange
+    List<MockEntry> mockEntries = new List<MockEntry>{
+      MockEntry.of(Opportunity.class),
+      MockEntry.of(Opportunity.class)
+    };
+    MockEloquent eloquent = new MockEloquent();
+
+    // Act
+    List<Database.UpsertResult> results = eloquent.label('upsert')
+      .doUpsertByExternalId(mockEntries, Opportunity.Id, false);
+
+    // Assert
+    for (Database.UpsertResult result : results) {
+      Assert.isNotNull(result.getId(), 'Each UpsertResult must carry the generated Id.');
+    }
+    for (MockEntry mockEntry : mockEntries) {
+      Assert.isNull(mockEntry.getId(), 'Input entries must not be mutated by the mock.');
+    }
+    for (SObject recorded : eloquent.upsertedRecordsAt('upsert')) {
+      Assert.isNotNull(recorded.Id, 'Recorded records must carry the generated Ids.');
+    }
   }
 
   @isTest

--- a/Entries/MockEntry.cls
+++ b/Entries/MockEntry.cls
@@ -1055,20 +1055,13 @@ public with sharing class MockEntry extends AbstractEntry {
    * @inheritDoc
    */
   public override Id getId() {
-    string method = 'getId()';
-    try {
-      this.validateFieldName('Id');
-    } catch (ApexEloquentException e) {
-      String reason = e.getMessage() + ', field: Id';
-      String action = 'Add the Id field to the Scribe definition for this object';
-      ApexEloquentException.message(CLASS_NAME, 'getId()', reason, action, e).fire();
-    }
-
     if (this.fieldToValue.containsKey('Id')) {
       return (Id) this.fieldToValue.get('Id');
     }
 
-    return (Id) this.record.get('Id');
+    // AggregateResult-based entries have no underlying record; real aggregate rows
+    // carry no implicit Id either, so null matches the platform behaviour.
+    return this.record == null ? null : (Id) this.record.get('Id');
   }
 
   /**
@@ -1261,7 +1254,9 @@ public with sharing class MockEntry extends AbstractEntry {
    */
   private void validateFieldName(String fieldName) {
     String lowerCaseFieldName = fieldName.toLowerCase();
-    if (this.skipFieldValidation || this.fieldStructure.hasField(lowerCaseFieldName)) {
+    // Real SOQL always returns Id regardless of the SELECT clause, so requiring a
+    // Scribe declaration for Id would make the mock stricter than the platform.
+    if (lowerCaseFieldName == 'id' || this.skipFieldValidation || this.fieldStructure.hasField(lowerCaseFieldName)) {
       return;
     }
 

--- a/Entries/tests/MockEntryTest.cls
+++ b/Entries/tests/MockEntryTest.cls
@@ -1165,7 +1165,7 @@ public class MockEntryTest {
   }
 
   @isTest
-  static void testGetId_WhenIdFieldDoesNotSelected_ThenThrowException() {
+  static void testGetId_WhenIdFieldDoesNotSelected_ThenReturnIdWithoutScribeDeclaration() {
     // Arrange
     SObject record = new Account(Id = '001000000000000', Name = 'Test Account');
     Scribe scribe = Scribe.of(Account.class).fields(new List<String>{ 'name' });
@@ -1173,15 +1173,23 @@ public class MockEntryTest {
     Map<String, Object> fieldToValue = new Map<String, Object>();
     MockEntry mockEntry = new MockEntry(record, fieldStructure, fieldToValue);
 
+    // Act
+    Id id = mockEntry.getId();
+
+    // Assert
+    // Real SOQL always returns Id regardless of the SELECT clause, so the mock
+    // must not require declaring it in the Scribe.
+    Assert.areEqual('001000000000000', id, 'Id should be readable without a Scribe declaration.');
+  }
+
+  @isTest
+  static void testGetId_WhenAggregateResultEntry_ThenReturnNull() {
+    // Arrange
+    MockEntry mockEntry = MockEntry.asAggregateResult(new Map<String, Object>{ 'total' => 5 });
+
     // Act & Assert
-    try {
-      mockEntry.getId();
-      Assert.fail('Expected ApexEloquentException to be thrown.');
-    } catch (ApexEloquentException e) {
-      String errorMessage = e.getMessage();
-      Assert.isTrue(errorMessage.contains('getId()'));
-      Assert.isTrue(errorMessage.contains('Add the Id field to the Scribe definition for this object'));
-    }
+    // Real aggregate rows carry no implicit Id, so null matches the platform behaviour.
+    Assert.isNull(mockEntry.getId(), 'Aggregate-based entries should return null Id like real aggregate rows.');
   }
 
   @isTest


### PR DESCRIPTION
## Summary

Closes #81, closes #82.

MockEloquent and MockEntry diverged from Eloquent/real SOQL in ways that made unit-test green fail to imply production green (and vice versa). This PR restores fidelity, and a full audit of the mock DML surface (prompted by these issues) fixes four more divergences of the same class.

## #81 — IEntry upsert Id handling

MockEloquent now mirrors Eloquent exactly:
- the caller's entry is never mutated (`entry.put('Id', ...)` removed)
- the generated Id is carried by the returned `Entry` instances, the `UpsertResult`, and `upsertedRecordsAt(...)`
- `doUpsert(List<IEntry>)` returns fresh `Entry` instances instead of aliasing the input list

Note: the issue mentions `mock.doInsert(entry)` as an affected pattern, but `doInsert` has no IEntry overload — the affected paths are exactly the four IEntry upsert methods.

## #82 — reading Id no longer requires a Scribe declaration

Real SOQL returns Id regardless of the SELECT clause, so `validateFieldName` now allows `id` unconditionally. Aggregate-based entries return `null` from `getId()`, matching real aggregate rows. The aggregate `get(alias)` path keeps its own declaration check, unchanged.

## Audit — the mock now fails where real DML fails

Platform behaviour was measured on API v67.0 before being encoded:

| operation | real DML | old mock |
|---|---|---|
| `doInsert` with an Id set | throws INVALID_FIELD_FOR_INSERT_UPDATE | silently overwrote the Id |
| `doUpdate` without an Id (allOrNone true/default) | throws MISSING_ARGUMENT | silently succeeded |
| `doUpdate` without an Id (allOrNone=false) | row-level MISSING_ARGUMENT failure, other rows processed | success SaveResult |
| `doDelete` without an Id | throws | silently succeeded |

`doUpdate(IEntry)`/`doUpdate(List<IEntry>)` also return fresh `Entry` instances now, matching Eloquent. Query paths (get/first/firstOrFail/rawSoql) were audited and already match.

## Compatibility

Method signatures are unchanged. Behaviour changes only where the mock deviated from the documented production contract, so this ships as a **minor** (behavioral bug fix): tests that relied on the old mock behaviour were passing against behaviour production does not have. Three such tests inside the framework were rewritten to assert the production-faithful behaviour.

## Tests

- 835/835 pass on v3 (13 new fidelity tests included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)